### PR TITLE
Add Serbian WordNet expansion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ target_synsets = pipeline.load_target_synsets()
 translated_synsets = pipeline.translate(english_synsets)
 ```
 
+### Serbian WordNet Expansion
+
+For Serbian-specific experiments, use `SerbianWordnetPipeline` which bundles
+English synset loading, placeholder generation and XML export:
+
+```python
+from pathlib import Path
+from wordnet_autotranslate import SerbianWordnetPipeline
+
+pipeline = SerbianWordnetPipeline(pilot_limit=100)
+pipeline.run(Path("./output/srpwn_generated.xml"))
+```
+
 ### Using Examples
 
 Place your target language examples in the `examples/` folder:

--- a/src/wordnet_autotranslate/__init__.py
+++ b/src/wordnet_autotranslate/__init__.py
@@ -9,11 +9,13 @@ __version__ = "0.1.0"
 __author__ = "WordNet Auto-Translation Contributors"
 
 from .pipelines.translation_pipeline import TranslationPipeline
+from .pipelines.serbian_wordnet_pipeline import SerbianWordnetPipeline
 from .models.synset_handler import SynsetHandler
 from .utils.language_utils import LanguageUtils
 
 __all__ = [
     "TranslationPipeline",
-    "SynsetHandler", 
-    "LanguageUtils"
+    "SerbianWordnetPipeline",
+    "SynsetHandler",
+    "LanguageUtils",
 ]

--- a/src/wordnet_autotranslate/pipelines/serbian_wordnet_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/serbian_wordnet_pipeline.py
@@ -95,7 +95,7 @@ class SerbianWordnetPipeline:
             literals=literals,
             gloss=gloss,
             examples=[f"Primer upotrebe za {literals[0]}."],
-            ilr=syn.get("hypernyms", []),
+            ilr=[h for h in syn.get("hypernyms", []) if isinstance(h, str)],
         )
 
     # ------------------------------------------------------------------

--- a/src/wordnet_autotranslate/pipelines/serbian_wordnet_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/serbian_wordnet_pipeline.py
@@ -1,0 +1,157 @@
+"""Pipeline for expanding Serbian WordNet using a large language model.
+
+This module provides a simplified workflow for loading English synsets from
+WordNet, generating Serbian translations with a language model via DSPy,
+optionally judging the output, and exporting the validated synsets to XML in
+WordNet-LMF-compatible format.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Iterable, Optional
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+try:
+    import nltk
+    from nltk.corpus import wordnet as wn
+
+    NLTK_AVAILABLE = True
+except ImportError:  # pragma: no cover - dependency may not be installed in tests
+    NLTK_AVAILABLE = False
+
+try:
+    import dspy  # type: ignore
+
+    DSPY_AVAILABLE = True
+except ImportError:  # pragma: no cover - dspy is optional for tests
+    DSPY_AVAILABLE = False
+
+
+@dataclass
+class SerbianSynset:
+    """Container for generated Serbian synset data."""
+
+    id: str
+    pos: str
+    literals: List[str]
+    gloss: str
+    examples: List[str] = field(default_factory=list)
+    ilr: List[str] = field(default_factory=list)
+
+
+class SerbianWordnetPipeline:
+    """Semi-automatic pipeline for Serbian WordNet expansion."""
+
+    def __init__(self, pilot_limit: int = 100) -> None:
+        self.pilot_limit = pilot_limit
+
+    # ------------------------------------------------------------------
+    # Loading English synsets
+    # ------------------------------------------------------------------
+    def load_english_synsets(self) -> List[Dict[str, object]]:
+        """Load English synsets from NLTK WordNet."""
+        if not NLTK_AVAILABLE:  # pragma: no cover - tested indirectly
+            raise RuntimeError(
+                "NLTK WordNet is not available. Install nltk to use this function."
+            )
+
+        synsets = []
+        for i, syn in enumerate(wn.all_synsets()):
+            if i >= self.pilot_limit:
+                break
+            synsets.append(
+                {
+                    "id": syn.name(),
+                    "pos": syn.pos(),
+                    "lemmas": [lemma.name() for lemma in syn.lemmas()],
+                    "gloss": syn.definition(),
+                    "examples": syn.examples(),
+                    "hypernyms": [h.name() for h in syn.hypernyms()],
+                }
+            )
+        return synsets
+
+    # ------------------------------------------------------------------
+    # Generation with a language model
+    # ------------------------------------------------------------------
+    def generate_serbian_synset(self, syn: Dict[str, object]) -> SerbianSynset:
+        """Generate a Serbian synset using DSPy or a placeholder implementation."""
+
+        # Placeholder implementation: prepend "srp_" to each lemma
+        literals = [f"srp_{lemma}" for lemma in syn.get("lemmas", [])]
+        gloss = f"(SRP) {syn.get('gloss', '')}"
+
+        if DSPY_AVAILABLE:
+            # In a real scenario, DSPy would be used to craft a prompt and call
+            # the underlying LLM. This placeholder shows the intended API usage.
+            _ = dspy.Example  # reference to keep linters quiet
+            # TODO: implement DSPy generation logic
+
+        return SerbianSynset(
+            id=str(syn.get("id")),
+            pos=str(syn.get("pos")),
+            literals=literals,
+            gloss=gloss,
+            examples=[f"Primer upotrebe za {literals[0]}."],
+            ilr=syn.get("hypernyms", []),
+        )
+
+    # ------------------------------------------------------------------
+    # Evaluation / judgment
+    # ------------------------------------------------------------------
+    def judge_synset(self, eng_synset: Dict[str, object], srp_synset: SerbianSynset) -> bool:
+        """Judge whether the generated Serbian synset is acceptable."""
+        # Placeholder evaluation: accept everything
+        if DSPY_AVAILABLE:
+            # Real implementation would query an LLM-as-judge here
+            pass
+        return True
+
+    # ------------------------------------------------------------------
+    # Export to XML
+    # ------------------------------------------------------------------
+    def export_to_xml(self, synsets: Iterable[SerbianSynset], output_path: Path) -> None:
+        """Write synsets to an XML file in WordNet-LMF style."""
+        root = ET.Element("SRPWN")
+
+        for syn in synsets:
+            s_elem = ET.SubElement(root, "SYNSET", id=syn.id, pos=syn.pos)
+            syn_elem = ET.SubElement(s_elem, "SYNONYM")
+            for lit in syn.literals:
+                lit_elem = ET.SubElement(syn_elem, "LITERAL")
+                lit_elem.text = lit
+                ET.SubElement(lit_elem, "SENSE").text = "1"
+            def_elem = ET.SubElement(s_elem, "DEF")
+            def_elem.text = syn.gloss
+
+            if syn.examples:
+                ex_elem = ET.SubElement(s_elem, "EXAMPLES")
+                for ex in syn.examples:
+                    one = ET.SubElement(ex_elem, "EXAMPLE")
+                    one.text = ex
+
+            if syn.ilr:
+                ilr_elem = ET.SubElement(s_elem, "ILR")
+                for target in syn.ilr:
+                    link = ET.SubElement(ilr_elem, "HYPERNYM")
+                    link.text = target
+
+        tree = ET.ElementTree(root)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        tree.write(output_path, encoding="utf-8", xml_declaration=True)
+
+    # ------------------------------------------------------------------
+    # Full pipeline
+    # ------------------------------------------------------------------
+    def run(self, output_xml: Path) -> None:
+        """Run the end-to-end generation and export process."""
+        english = self.load_english_synsets()
+        generated: List[SerbianSynset] = []
+        for syn in english:
+            srp = self.generate_serbian_synset(syn)
+            if self.judge_synset(syn, srp):
+                generated.append(srp)
+        self.export_to_xml(generated, output_xml)
+

--- a/src/wordnet_autotranslate/pipelines/serbian_wordnet_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/serbian_wordnet_pipeline.py
@@ -94,7 +94,7 @@ class SerbianWordnetPipeline:
             pos=str(syn.get("pos")),
             literals=literals,
             gloss=gloss,
-            examples=[f"Primer upotrebe za {literals[0]}."],
+            examples=[f"Primer upotrebe za {literals[0]}." if literals else "Primer upotrebe nije dostupan."],
             ilr=[h for h in syn.get("hypernyms", []) if isinstance(h, str)],
         )
 

--- a/src/wordnet_autotranslate/pipelines/serbian_wordnet_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/serbian_wordnet_pipeline.py
@@ -147,11 +147,13 @@ class SerbianWordnetPipeline:
     # ------------------------------------------------------------------
     def run(self, output_xml: Path) -> None:
         """Run the end-to-end generation and export process."""
-        english = self.load_english_synsets()
-        generated: List[SerbianSynset] = []
-        for syn in english:
-            srp = self.generate_serbian_synset(syn)
-            if self.judge_synset(syn, srp):
-                generated.append(srp)
-        self.export_to_xml(generated, output_xml)
-
+        try:
+            english = self.load_english_synsets()
+            generated: List[SerbianSynset] = []
+            for syn in english:
+                srp = self.generate_serbian_synset(syn)
+                if self.judge_synset(syn, srp):
+                    generated.append(srp)
+            self.export_to_xml(generated, output_xml)
+        except Exception as e:
+            raise RuntimeError(f"Pipeline execution failed: {e}") from e

--- a/src/wordnet_autotranslate/pipelines/serbian_wordnet_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/serbian_wordnet_pipeline.py
@@ -86,7 +86,7 @@ class SerbianWordnetPipeline:
         if DSPY_AVAILABLE:
             # In a real scenario, DSPy would be used to craft a prompt and call
             # the underlying LLM. This placeholder shows the intended API usage.
-            _ = dspy.Example  # reference to keep linters quiet
+            self._placeholder_dspy_usage()
             # TODO: implement DSPy generation logic
 
         return SerbianSynset(


### PR DESCRIPTION
## Summary
- add SerbianWordnetPipeline for loading English synsets, placeholder generation, judging and XML export
- expose new pipeline in package init
- document usage example in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8b6cfc888329a154293c8293378d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new pipeline for expanding the Serbian WordNet using a large language model, supporting XML export.
* **Documentation**
  * Added a detailed README section explaining the Serbian WordNet Expansion pipeline, with usage instructions and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->