### PR TITLE
Handle optional GUI dependencies and add regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ pip install -e .
 pip install -e ".[notebooks,gui,dev]"
 ```
 
+### Optional dependencies
+
+The base library runs without heavy GUI packages. Install the ``gui``
+extra to enable the interactive browser, which pulls in optional
+dependencies ``streamlit`` and ``pandas``:
+
+```bash
+pip install -e ".[gui]"
+```
+
+These packages are only required for GUI features; core translation
+utilities work in headless environments.
+
 3. Set up Jupyter environment (optional):
 ```bash
 # Install with notebook dependencies
@@ -47,7 +60,9 @@ jupyter notebook
 
 ### Serbian WordNet Synset Browser (GUI)
 
-Launch the interactive GUI for browsing and pairing Serbian synsets:
+Launch the interactive GUI for browsing and pairing Serbian synsets.
+This component requires the optional ``streamlit`` and ``pandas``
+dependencies (install via ``pip install -e ".[gui]"``):
 
 ```bash
 # Using the launcher script

--- a/src/wordnet_autotranslate/gui/__init__.py
+++ b/src/wordnet_autotranslate/gui/__init__.py
@@ -1,5 +1,9 @@
-"""
-GUI package for WordNet synset browsing.
+"""GUI package for WordNet synset browsing.
+
+This subpackage depends on optional GUI libraries. Installing the
+``gui`` extra adds :mod:`streamlit` for the web interface and
+``pandas`` for table rendering. Core functionality of the project can
+be used without these dependencies.
 """
 
 __all__ = ["synset_browser"]

--- a/src/wordnet_autotranslate/gui/synset_browser.py
+++ b/src/wordnet_autotranslate/gui/synset_browser.py
@@ -17,6 +17,14 @@ The application follows best practices including:
 
 Author: Serbian WordNet Team
 Version: 2.0 (Refactored)
+
+Optional Dependencies
+---------------------
+The GUI relies on :mod:`streamlit` and uses :mod:`pandas` for table
+rendering and data export. These packages are optional; the rest of the
+project can run in headless environments. Features that require them
+will raise :class:`ImportError` when absent. Heavy WordNet resources are
+also loaded lazily to avoid unnecessary downloads during import.
 """
 
 import json

--- a/tests/test_gui_optional_deps.py
+++ b/tests/test_gui_optional_deps.py
@@ -1,0 +1,20 @@
+"""Tests for optional GUI dependencies (pandas/streamlit)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add src to path for testing
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from wordnet_autotranslate.gui import synset_browser as sb
+
+
+def test_export_pairs_requires_pandas(monkeypatch):
+    """_export_pairs should raise ImportError when pandas is unavailable."""
+    monkeypatch.setattr(sb, "pd", None)
+    app = sb.SynsetBrowserApp()
+    sb.st.session_state[sb.SESSION_SELECTED_PAIRS] = [{"dummy": 1}]
+    with pytest.raises(ImportError):
+        app._export_pairs()


### PR DESCRIPTION
## Summary
- make pandas and streamlit optional to allow headless usage
- lazily initialize SynsetHandler to avoid heavyweight NLTK downloads in tests
- add regression test covering missing pandas behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3564186888329bad8261488a61257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * GUI now supports optional dependencies, with lazy-loading of resources and clear errors when missing packages are required.
* Bug Fixes
  * Improved resilience to missing GUI dependencies to prevent unexpected crashes.
* Documentation
  * Added an “Optional dependencies” section with install instructions (pip install -e ".[gui]") and clarified when GUI packages are needed.
* Refactor
  * Streamlined initialization to better handle optional components and reduce overhead.
* Tests
  * Added tests to validate behavior when GUI dependencies are not installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->