### PR TITLE
test: add SynsetHandler WordNet integration tests

### DIFF
--- a/tests/test_synset_handler.py
+++ b/tests/test_synset_handler.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add src to path for testing
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from wordnet_autotranslate.models.synset_handler import (
+    SynsetHandler,
+    WordNetNotAvailableError,
+)
+import wordnet_autotranslate.models.synset_handler as synset_module
+
+
+def test_get_synset_by_offset_returns_expected():
+    """SynsetHandler retrieves known synset by offset and POS."""
+    handler = SynsetHandler()
+    synset = handler.get_synset_by_offset("03574555", "n")
+    assert synset is not None
+    assert synset["name"] == "institution.n.02"
+    assert isinstance(synset["definition"], str) and synset["definition"]
+
+
+def test_get_synsets_by_relation_hypernyms():
+    """SynsetHandler returns hypernyms for a known synset."""
+    handler = SynsetHandler()
+    related = handler.get_synsets_by_relation("dog.n.01", "hypernyms")
+    names = {r["name"] for r in related}
+    assert "canine.n.02" in names or "domestic_animal.n.01" in names
+
+
+def test_get_relation_summary_counts():
+    """Summary includes counts for relations like hypernyms."""
+    handler = SynsetHandler()
+    summary = handler.get_relation_summary("dog.n.01")
+    assert summary["synset"] == "dog.n.01"
+    assert summary["relation_counts"]["hypernyms"] > 0
+
+
+def test_wordnet_not_available(monkeypatch):
+    """Raises WordNetNotAvailableError when NLTK is missing."""
+    monkeypatch.setattr(synset_module, "NLTK_AVAILABLE", False)
+    with pytest.raises(WordNetNotAvailableError):
+        SynsetHandler()


### PR DESCRIPTION
## Summary
- add integration tests covering SynsetHandler retrieval and relation lookups via NLTK WordNet
- verify graceful failure when NLTK WordNet is unavailable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb9f6bc688329822af3ba317b64af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for synset retrieval by offset, relation fetching (e.g., hypernyms), and relation summaries.
  * Verified graceful error handling when WordNet data is unavailable.
  * Improves reliability and confidence in core synset features without changing user-facing behavior.
  * No changes to public APIs; functionality remains the same for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->