### PR TITLE
Add agent-friendly synset translation workflow and CLI; harden LangGraph pipeline and update metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Instructions for wordnet_autotranslate-
+
+## Preferred workflow skills
+- Use `skills/translate-synset-serbian/SKILL.md` when users request English WordNet synset translation to Serbian.
+- Prefer selector-based lookup (`--english-id`, `--synset-name`, or `--lemma` + `--pos`) over ad-hoc prompt-only translation.
+
+## Operational guidance
+- For reproducible runs, use `scripts/translate_synset_workflow.py`.
+- Default pipeline: `langgraph`; use `all` for side-by-side comparison output.
+- Use `--strict` for fail-fast automation; omit it for best-effort multi-pipeline reports.
+
+## Safety
+- Do not log secrets.
+- Keep prompts and outputs in structured JSON where possible.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ resolution and single/multi-pipeline execution), use:
 python scripts/translate_synset_workflow.py --english-id ENG30-00001740-n --pipeline all --model gpt-oss:120b
 ```
 
+Use `--strict` to fail fast when any selected pipeline errors.
+
 Skill documentation for agents is available at:
 `skills/translate-synset-serbian/SKILL.md`.
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ translations = pipeline.translate(synsets)
 # - payload: full JSON logs (sense analysis, definition translation, synonym decisions)
 ```
 
+### Agent workflow: translate by synset ID/name/lemma
+
+For agent-compatible, repeatable translation workflows (including selector
+resolution and single/multi-pipeline execution), use:
+
+```bash
+python scripts/translate_synset_workflow.py --english-id ENG30-00001740-n --pipeline all --model gpt-oss:120b
+```
+
+Skill documentation for agents is available at:
+`skills/translate-synset-serbian/SKILL.md`.
+
 ### Concept-oriented LangGraph comparison pipeline
 
 To compare the existing generate-and-filter pipeline with a stricter

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ This project supports expansion to any language. Current examples include:
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under CC0 1.0 Universal (CC0-1.0) - see the LICENSE file for details.
 
 ## Acknowledgments
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ authors = [
 ]
 description = "Automatic expansion of WordNet in less-resourced languages using DSPy"
 readme = "README.md"
-license = {text = "MIT"}
+license = {text = "CC0-1.0"}
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
+    "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",

--- a/scripts/translate_synset_workflow.py
+++ b/scripts/translate_synset_workflow.py
@@ -34,6 +34,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--target-lang", default="sr")
     parser.add_argument("--timeout", type=int, default=600)
     parser.add_argument("--temperature", type=float, default=0.2)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail immediately if any selected pipeline errors.",
+    )
     return parser
 
 
@@ -56,6 +61,7 @@ def main() -> int:
             timeout=args.timeout,
             base_url=args.base_url,
             temperature=args.temperature,
+            strict=args.strict,
         )
         result = run_translation_workflow(
             synset_payload,

--- a/scripts/translate_synset_workflow.py
+++ b/scripts/translate_synset_workflow.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""CLI wrapper for agent-friendly synset translation workflow."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from wordnet_autotranslate.workflows.synset_translation_workflow import (
+    WorkflowConfig,
+    resolve_wordnet_synset,
+    results_to_json,
+    run_translation_workflow,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Translate an English WordNet synset to Serbian.")
+    parser.add_argument("--english-id", help="ENG30 ID (e.g., ENG30-00001740-n)")
+    parser.add_argument("--synset-name", help="WordNet synset name (e.g., entity.n.01)")
+    parser.add_argument("--lemma", help="English lemma (requires --pos)")
+    parser.add_argument("--pos", help="POS tag: n|v|a|r (Serbian b is accepted)")
+    parser.add_argument("--sense-index", type=int, default=1, help="1-based sense index for lemma lookup")
+
+    parser.add_argument(
+        "--pipeline",
+        default="langgraph",
+        choices=["langgraph", "conceptual", "all", "dspy"],
+        help="Pipeline(s) to run",
+    )
+    parser.add_argument("--model", default="gpt-oss:120b", help="Ollama model name")
+    parser.add_argument("--base-url", default="http://localhost:11434", help="Ollama base URL")
+    parser.add_argument("--source-lang", default="en")
+    parser.add_argument("--target-lang", default="sr")
+    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument("--temperature", type=float, default=0.2)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        synset_payload = resolve_wordnet_synset(
+            english_id=args.english_id,
+            synset_name=args.synset_name,
+            lemma=args.lemma,
+            pos=args.pos,
+            sense_index=args.sense_index,
+        )
+        config = WorkflowConfig(
+            source_lang=args.source_lang,
+            target_lang=args.target_lang,
+            model=args.model,
+            timeout=args.timeout,
+            base_url=args.base_url,
+            temperature=args.temperature,
+        )
+        result = run_translation_workflow(
+            synset_payload,
+            pipeline=args.pipeline,
+            config=config,
+        )
+        print(results_to_json(result))
+        return 0
+    except Exception as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/translate_synset_workflow.py
+++ b/scripts/translate_synset_workflow.py
@@ -46,6 +46,9 @@ def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
 
+    if args.lemma and not args.pos:
+        parser.error("--lemma requires --pos")
+
     try:
         synset_payload = resolve_wordnet_synset(
             english_id=args.english_id,
@@ -70,8 +73,10 @@ def main() -> int:
         )
         print(results_to_json(result))
         return 0
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
-        print(f"[ERROR] {exc}", file=sys.stderr)
+        print(f"[ERROR] {type(exc).__name__}: {exc}", file=sys.stderr)
         return 1
 
 

--- a/skills/translate-synset-serbian/SKILL.md
+++ b/skills/translate-synset-serbian/SKILL.md
@@ -12,7 +12,7 @@ Use this skill when the user asks to translate by any of:
 ## Pipelines supported
 - `langgraph` (LangGraphTranslationPipeline)
 - `conceptual` (ConceptualLangGraphTranslationPipeline)
-- `all` (runs both)
+- `all` (runs LangGraph + Conceptual + DSPy placeholder)
 - `dspy` (reports not implemented in current repo)
 
 ## Workflow
@@ -37,3 +37,4 @@ python scripts/translate_synset_workflow.py --lemma entity --pos n --sense-index
 - Requires NLTK WordNet availability for lookup.
 - LangGraph pipelines require optional dependencies and a reachable Ollama endpoint.
 - Serbian adverb POS (`b`) is normalized to WordNet adverb POS (`r`) automatically.
+- Add `--strict` when you want non-zero exit on any per-pipeline error.

--- a/skills/translate-synset-serbian/SKILL.md
+++ b/skills/translate-synset-serbian/SKILL.md
@@ -1,0 +1,39 @@
+# Skill: translate-synset-serbian
+
+## Purpose
+Agent workflow for translating an English WordNet synset to Serbian using one or multiple pipelines in this repository and an Ollama model.
+
+## When to use
+Use this skill when the user asks to translate by any of:
+- English synset ID (`ENG30-########-<pos>`)
+- WordNet synset name (`lemma.pos.nn`, e.g. `entity.n.01`)
+- lemma + POS (+ optional sense index)
+
+## Pipelines supported
+- `langgraph` (LangGraphTranslationPipeline)
+- `conceptual` (ConceptualLangGraphTranslationPipeline)
+- `all` (runs both)
+- `dspy` (reports not implemented in current repo)
+
+## Workflow
+1. Resolve synset selector into canonical payload using:
+   - `wordnet_autotranslate.workflows.synset_translation_workflow.resolve_wordnet_synset`
+2. Run selected pipeline(s):
+   - `run_translation_workflow(..., pipeline=...)`
+3. Return JSON output for downstream curation.
+
+## CLI usage
+```bash
+python scripts/translate_synset_workflow.py --english-id ENG30-00001740-n --pipeline all --model gpt-oss:120b
+```
+
+Alternative selectors:
+```bash
+python scripts/translate_synset_workflow.py --synset-name entity.n.01 --pipeline langgraph
+python scripts/translate_synset_workflow.py --lemma entity --pos n --sense-index 1 --pipeline conceptual
+```
+
+## Notes
+- Requires NLTK WordNet availability for lookup.
+- LangGraph pipelines require optional dependencies and a reachable Ollama endpoint.
+- Serbian adverb POS (`b`) is normalized to WordNet adverb POS (`r`) automatically.

--- a/src/wordnet_autotranslate/__init__.py
+++ b/src/wordnet_autotranslate/__init__.py
@@ -17,6 +17,11 @@ from .pipelines.serbian_wordnet_pipeline import SerbianWordnetPipeline
 from .models.synset_handler import SynsetHandler
 from .models.xml_synset_parser import XmlSynsetParser, Synset
 from .utils.language_utils import LanguageUtils
+from .workflows.synset_translation_workflow import (
+    WorkflowConfig,
+    resolve_wordnet_synset,
+    run_translation_workflow,
+)
 
 __all__ = [
     "TranslationPipeline",
@@ -27,4 +32,7 @@ __all__ = [
     "XmlSynsetParser",
     "Synset",
     "LanguageUtils",
+    "WorkflowConfig",
+    "resolve_wordnet_synset",
+    "run_translation_workflow",
 ]

--- a/src/wordnet_autotranslate/pipelines/langgraph_translation_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/langgraph_translation_pipeline.py
@@ -669,8 +669,20 @@ class LangGraphTranslationPipeline:
                 self._HumanMessage(content=prompt),
             ]
 
-            response = self.llm.invoke(messages)
-            content: Any = getattr(response, "content", response)
+            try:
+                response = self.llm.invoke(messages)
+                content: Any = getattr(response, "content", response)
+            except Exception as exc:
+                raw = str(exc)
+                if attempt < retries:
+                    print(
+                        f"[Retry {attempt + 1}/{retries}] LLM invoke failed for stage '{stage}': {exc}"
+                    )
+                    continue
+                print(
+                    f"[ERROR] LLM invoke failed for stage '{stage}' after retries: {exc}"
+                )
+                break
 
             if isinstance(content, list):
                 combined = "".join(
@@ -893,12 +905,12 @@ class LangGraphTranslationPipeline:
     @staticmethod
     def _coerce_to_str_list(value: Any) -> List[str]:
         """Normalise unknown payload values into a cleaned list of strings."""
-        if value is None:
-            return []
         if isinstance(value, (list, tuple)):
-            return [str(item).strip() for item in value if str(item).strip()]
-        text = str(value).strip()
-        return [text] if text else []
+            return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+        if isinstance(value, str):
+            text = value.strip()
+            return [text] if text else []
+        return []
 
     def _assemble_result(self, state: TranslationGraphState) -> TranslationGraphState:
         """LangGraph node: Combine all stage outputs into final result.

--- a/src/wordnet_autotranslate/pipelines/langgraph_translation_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/langgraph_translation_pipeline.py
@@ -660,6 +660,8 @@ class LangGraphTranslationPipeline:
         Returns:
             Dict containing prompt, response, parsed payload, and metadata.
         """
+        system_content = ""
+        raw = ""
         for attempt in range(retries + 1):
             system_content = self.system_prompt + f"\nCurrent stage: {stage}. Return valid JSON as instructed."
             messages = [
@@ -704,19 +706,21 @@ class LangGraphTranslationPipeline:
         
         # Fallback return after max retries
         print(f"[ERROR] Max retries exceeded for stage '{stage}', returning error payload")
+        fallback_payload = self._validate_payload_for_stage(stage, {})
+        if not fallback_payload:
+            fallback_payload = {"error": "max retries exceeded"}
+
         return {
             "stage": stage,
             "prompt": prompt,
             "system_prompt": system_content,
             "raw_response": raw,
-            "payload": {"error": "max retries exceeded"},
+            "payload": fallback_payload,
             "messages": [
                 {"role": "system", "content": system_content},
                 {"role": "user", "content": prompt},
             ],
         }
-
-        return call_log
 
     @staticmethod
     def _summarise_call(call: Dict[str, Any]) -> Dict[str, Any]:
@@ -862,7 +866,7 @@ class LangGraphTranslationPipeline:
                 return {}
             
             offset_str = parts[1]
-            pos_char = parts[2]
+            pos_char = LanguageUtils.normalize_pos_for_english(parts[2])
             
             # Convert offset to integer
             offset = int(offset_str)
@@ -885,13 +889,16 @@ class LangGraphTranslationPipeline:
         except (ValueError, LookupError, AttributeError):
             # Could not parse or find synset
             return {}
-            
-            # Return the lexname (domain)
-            return synset.lexname()
-            
-        except (ValueError, LookupError, AttributeError):
-            # Could not parse or find synset
-            return None
+
+    @staticmethod
+    def _coerce_to_str_list(value: Any) -> List[str]:
+        """Normalise unknown payload values into a cleaned list of strings."""
+        if value is None:
+            return []
+        if isinstance(value, (list, tuple)):
+            return [str(item).strip() for item in value if str(item).strip()]
+        text = str(value).strip()
+        return [text] if text else []
 
     def _assemble_result(self, state: TranslationGraphState) -> TranslationGraphState:
         """LangGraph node: Combine all stage outputs into final result.
@@ -923,16 +930,8 @@ class LangGraphTranslationPipeline:
 
         # Extract the final, validated synonyms from the filtering stage
         # This is the high-quality synset produced by the generate-and-filter pipeline
-        translated_synonyms: List[str] = []
         filtered_synonyms = filtering_payload.get("filtered_synonyms", [])
-        
-        if isinstance(filtered_synonyms, (list, tuple)):
-            for syn in filtered_synonyms:
-                if syn:
-                    translated_synonyms.append(str(syn).strip())
-        elif filtered_synonyms:
-            # Handle single string case
-            translated_synonyms.append(str(filtered_synonyms).strip())
+        translated_synonyms = self._coerce_to_str_list(filtered_synonyms)
         
         # Remove any empty strings and deduplicate while preserving order
         seen = set()
@@ -950,12 +949,8 @@ class LangGraphTranslationPipeline:
         translation = translated_synonyms[0] if translated_synonyms else ""
 
         # Gather examples from definition translation
-        examples: List[str] = []
         definition_examples = definition_payload.get("examples")
-        if isinstance(definition_examples, (list, tuple)):
-            examples.extend(str(ex).strip() for ex in definition_examples if ex)
-        elif isinstance(definition_examples, str) and definition_examples.strip():
-            examples.append(definition_examples.strip())
+        examples = self._coerce_to_str_list(definition_examples)
 
         # Deduplicate examples while preserving order
         seen_examples = set()
@@ -1012,8 +1007,14 @@ class LangGraphTranslationPipeline:
         
         # Add pipeline stage info
         summary_lines.append(f"\nPipeline stages completed:")
-        summary_lines.append(f"  1. Initial translations: {len(initial_payload.get('initial_translations', []))} lemmas")
-        summary_lines.append(f"  2. Expanded candidates: {len(expansion_payload.get('expanded_synonyms', []))} synonyms")
+        summary_lines.append(
+            "  1. Initial translations: "
+            f"{len(self._coerce_to_str_list(initial_payload.get('initial_translations')))} lemmas"
+        )
+        summary_lines.append(
+            "  2. Expanded candidates: "
+            f"{len(self._coerce_to_str_list(expansion_payload.get('expanded_synonyms')))} synonyms"
+        )
         summary_lines.append(f"  3. Filtered results: {len(translated_synonyms)} final literals")
 
         curator_summary = "\n".join(summary_lines)

--- a/src/wordnet_autotranslate/utils/language_utils.py
+++ b/src/wordnet_autotranslate/utils/language_utils.py
@@ -65,6 +65,7 @@ class LanguageUtils:
         'n': 'n',
         'v': 'v',
         'a': 'a',
+        's': 'a',  # satellite adjective -> adjective for WordNet lookups
         # keep any other tag as-is by default
     }
 

--- a/src/wordnet_autotranslate/workflows/__init__.py
+++ b/src/wordnet_autotranslate/workflows/__init__.py
@@ -1,0 +1,17 @@
+"""Workflow utilities for agent-oriented translation operations."""
+
+from .synset_translation_workflow import (
+    WorkflowConfig,
+    parse_eng30_id,
+    resolve_wordnet_synset,
+    run_translation_workflow,
+    synset_to_payload,
+)
+
+__all__ = [
+    "WorkflowConfig",
+    "parse_eng30_id",
+    "resolve_wordnet_synset",
+    "run_translation_workflow",
+    "synset_to_payload",
+]

--- a/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
+++ b/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
@@ -40,7 +40,7 @@ def parse_eng30_id(english_id: str) -> Tuple[int, str]:
         )
 
     offset_token = parts[1]
-    if len(offset_token) != 8 or not offset_token.isdigit():
+    if len(offset_token) != 8 or not offset_token.isascii() or not offset_token.isdigit():
         raise ValueError(
             f"parse_eng30_id: invalid offset in selector {english_id!r}; offset must be exactly 8 digits."
         )

--- a/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
+++ b/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
@@ -36,7 +36,7 @@ def parse_eng30_id(english_id: str) -> Tuple[int, str]:
     parts = str(english_id).strip().split("-")
     if len(parts) != 3 or parts[0] != "ENG30":
         raise ValueError(
-            f"parse_eng30_id: invalid selector {english_id!r}; expected 'ENG30-########-[n|v|a|r|b]'."
+            f"parse_eng30_id: invalid selector {english_id!r}; expected 'ENG30-########-[n|v|a|s|r]'."
         )
 
     try:
@@ -46,10 +46,15 @@ def parse_eng30_id(english_id: str) -> Tuple[int, str]:
             f"parse_eng30_id: invalid offset in selector {english_id!r}; offset must be an integer."
         ) from exc
 
-    pos = LanguageUtils.normalize_pos_for_english(parts[2].lower())
+    raw_pos = parts[2].lower()
+    if raw_pos not in {"n", "v", "a", "s", "r", "b"}:
+        raise ValueError(
+            f"parse_eng30_id: invalid POS in selector {english_id!r}; expected one of n,v,a,s,r."
+        )
+    pos = LanguageUtils.normalize_pos_for_english(raw_pos)
     if pos not in {"n", "v", "a", "r"}:
         raise ValueError(
-            f"parse_eng30_id: invalid POS in selector {english_id!r}; expected one of n,v,a,r,b."
+            f"parse_eng30_id: invalid POS mapping in selector {english_id!r}; normalized POS={pos!r} is unsupported."
         )
 
     return offset, pos

--- a/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
+++ b/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
@@ -14,6 +14,7 @@ import json
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..pipelines.translation_pipeline import TranslationPipeline
 from ..pipelines.conceptual_langgraph_pipeline import ConceptualLangGraphTranslationPipeline
 from ..pipelines.langgraph_translation_pipeline import LangGraphTranslationPipeline
 from ..utils.language_utils import LanguageUtils
@@ -27,6 +28,7 @@ class WorkflowConfig:
     timeout: int = 600
     base_url: str = "http://localhost:11434"
     temperature: float = 0.2
+    strict: bool = False
 
 
 def parse_eng30_id(english_id: str) -> Tuple[int, str]:
@@ -114,6 +116,17 @@ def run_translation_workflow(
         "pipelines": {},
     }
 
+    def _run_with_capture(name: str, runner: Any) -> None:
+        try:
+            results["pipelines"][name] = runner()
+        except Exception as exc:
+            if config.strict:
+                raise
+            results["pipelines"][name] = {
+                "status": "error",
+                "message": str(exc),
+            }
+
     if selected in {"langgraph", "all"}:
         lg = LangGraphTranslationPipeline(
             source_lang=config.source_lang,
@@ -123,7 +136,7 @@ def run_translation_workflow(
             base_url=config.base_url,
             temperature=config.temperature,
         )
-        results["pipelines"]["langgraph"] = lg.translate_synset(synset_payload)
+        _run_with_capture("langgraph", lambda: lg.translate_synset(synset_payload))
 
     if selected in {"conceptual", "all"}:
         cg = ConceptualLangGraphTranslationPipeline(
@@ -134,13 +147,21 @@ def run_translation_workflow(
             base_url=config.base_url,
             temperature=config.temperature,
         )
-        results["pipelines"]["conceptual"] = cg.translate_synset(synset_payload)
+        _run_with_capture("conceptual", lambda: cg.translate_synset(synset_payload))
 
-    if selected == "dspy":
-        results["pipelines"]["dspy"] = {
-            "status": "not_implemented",
-            "message": "TranslationPipeline.translate is currently a TODO in this repository.",
-        }
+    if selected in {"dspy", "all"}:
+        dspy_pipeline = TranslationPipeline(
+            source_lang=config.source_lang,
+            target_lang=config.target_lang,
+        )
+        dspy_output = dspy_pipeline.translate([synset_payload])
+        if dspy_output:
+            results["pipelines"]["dspy"] = dspy_output[0]
+        else:
+            results["pipelines"]["dspy"] = {
+                "status": "not_implemented",
+                "message": "TranslationPipeline.translate currently returns no outputs for synsets.",
+            }
 
     if not results["pipelines"]:
         raise ValueError("Unsupported pipeline. Use: langgraph | conceptual | all | dspy")

--- a/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
+++ b/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
@@ -1,0 +1,153 @@
+"""Agent-friendly workflow for translating English WordNet synsets into Serbian.
+
+Supports lookup by:
+- ENG30 synset ID (e.g. ENG30-00001740-n)
+- Synset name (e.g. entity.n.01)
+- Lemma + POS + sense index (e.g. lemma=entity, pos=n, sense=1)
+
+And execution via one or multiple pipelines.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..pipelines.conceptual_langgraph_pipeline import ConceptualLangGraphTranslationPipeline
+from ..pipelines.langgraph_translation_pipeline import LangGraphTranslationPipeline
+from ..utils.language_utils import LanguageUtils
+
+
+@dataclass(frozen=True)
+class WorkflowConfig:
+    source_lang: str = "en"
+    target_lang: str = "sr"
+    model: str = "gpt-oss:120b"
+    timeout: int = 600
+    base_url: str = "http://localhost:11434"
+    temperature: float = 0.2
+
+
+def parse_eng30_id(english_id: str) -> Tuple[int, str]:
+    """Parse ENG30 IDs into (offset, pos)."""
+    parts = str(english_id).strip().split("-")
+    if len(parts) < 3:
+        raise ValueError(f"Invalid ENG30 id format: {english_id}")
+    offset = int(parts[1])
+    pos = LanguageUtils.normalize_pos_for_english(parts[2])
+    return offset, pos
+
+
+def synset_to_payload(synset: Any) -> Dict[str, Any]:
+    """Convert an NLTK WordNet synset object into pipeline payload format."""
+    try:
+        offset = synset.offset()
+        pos = synset.pos()
+        name = synset.name()
+        definition = synset.definition()
+        examples = synset.examples()
+        lemmas = [lemma.name().replace("_", " ") for lemma in synset.lemmas()]
+    except AttributeError as exc:
+        raise ValueError("Provided object is not a valid WordNet synset") from exc
+
+    return {
+        "id": f"ENG30-{offset:08d}-{pos}",
+        "english_id": f"ENG30-{offset:08d}-{pos}",
+        "name": name,
+        "lemmas": lemmas,
+        "definition": definition,
+        "examples": examples,
+        "pos": pos,
+    }
+
+
+def resolve_wordnet_synset(
+    *,
+    english_id: Optional[str] = None,
+    synset_name: Optional[str] = None,
+    lemma: Optional[str] = None,
+    pos: Optional[str] = None,
+    sense_index: int = 1,
+) -> Dict[str, Any]:
+    """Resolve a synset from one of the supported selectors and return payload."""
+    from nltk.corpus import wordnet as wn
+
+    if english_id:
+        offset, mapped_pos = parse_eng30_id(english_id)
+        synset = wn.synset_from_pos_and_offset(mapped_pos, offset)
+        return synset_to_payload(synset)
+
+    if synset_name:
+        synset = wn.synset(synset_name)
+        return synset_to_payload(synset)
+
+    if lemma and pos:
+        mapped_pos = LanguageUtils.normalize_pos_for_english(pos)
+        candidates = wn.synsets(lemma, pos=mapped_pos)
+        if not candidates:
+            raise LookupError(f"No synsets found for lemma={lemma!r}, pos={pos!r}")
+        idx = max(1, sense_index) - 1
+        if idx >= len(candidates):
+            raise LookupError(
+                f"sense_index={sense_index} out of range; available senses={len(candidates)}"
+            )
+        return synset_to_payload(candidates[idx])
+
+    raise ValueError(
+        "Provide one selector: english_id OR synset_name OR lemma+pos."
+    )
+
+
+def run_translation_workflow(
+    synset_payload: Dict[str, Any],
+    *,
+    pipeline: str = "langgraph",
+    config: WorkflowConfig = WorkflowConfig(),
+) -> Dict[str, Any]:
+    """Run requested pipeline(s) for a synset payload."""
+    selected = pipeline.lower().strip()
+
+    results: Dict[str, Any] = {
+        "selector_id": synset_payload.get("id") or synset_payload.get("english_id"),
+        "source_synset": synset_payload,
+        "pipelines": {},
+    }
+
+    if selected in {"langgraph", "all"}:
+        lg = LangGraphTranslationPipeline(
+            source_lang=config.source_lang,
+            target_lang=config.target_lang,
+            model=config.model,
+            timeout=config.timeout,
+            base_url=config.base_url,
+            temperature=config.temperature,
+        )
+        results["pipelines"]["langgraph"] = lg.translate_synset(synset_payload)
+
+    if selected in {"conceptual", "all"}:
+        cg = ConceptualLangGraphTranslationPipeline(
+            source_lang=config.source_lang,
+            target_lang=config.target_lang,
+            model=config.model,
+            timeout=config.timeout,
+            base_url=config.base_url,
+            temperature=config.temperature,
+        )
+        results["pipelines"]["conceptual"] = cg.translate_synset(synset_payload)
+
+    if selected == "dspy":
+        results["pipelines"]["dspy"] = {
+            "status": "not_implemented",
+            "message": "TranslationPipeline.translate is currently a TODO in this repository.",
+        }
+
+    if not results["pipelines"]:
+        raise ValueError("Unsupported pipeline. Use: langgraph | conceptual | all | dspy")
+
+    return results
+
+
+def results_to_json(data: Dict[str, Any]) -> str:
+    """Serialize workflow output for CLI/tools."""
+    return json.dumps(data, ensure_ascii=False, indent=2)

--- a/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
+++ b/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
@@ -34,11 +34,40 @@ class WorkflowConfig:
 def parse_eng30_id(english_id: str) -> Tuple[int, str]:
     """Parse ENG30 IDs into (offset, pos)."""
     parts = str(english_id).strip().split("-")
-    if len(parts) < 3:
-        raise ValueError(f"Invalid ENG30 id format: {english_id}")
-    offset = int(parts[1])
-    pos = LanguageUtils.normalize_pos_for_english(parts[2])
+    if len(parts) != 3 or parts[0] != "ENG30":
+        raise ValueError(
+            f"parse_eng30_id: invalid selector {english_id!r}; expected 'ENG30-########-[n|v|a|r|b]'."
+        )
+
+    try:
+        offset = int(parts[1])
+    except ValueError as exc:
+        raise ValueError(
+            f"parse_eng30_id: invalid offset in selector {english_id!r}; offset must be an integer."
+        ) from exc
+
+    pos = LanguageUtils.normalize_pos_for_english(parts[2].lower())
+    if pos not in {"n", "v", "a", "r"}:
+        raise ValueError(
+            f"parse_eng30_id: invalid POS in selector {english_id!r}; expected one of n,v,a,r,b."
+        )
+
     return offset, pos
+
+
+def _resolve_sense_index(sense_index: int, candidate_count: int) -> int:
+    """Resolve 1-based sense index to zero-based list index."""
+    if sense_index <= 0:
+        raise ValueError(
+            f"sense-index resolution routine: invalid sense_index={sense_index}; expected positive integer."
+        )
+    idx = sense_index - 1
+    if idx >= candidate_count:
+        raise ValueError(
+            "sense-index resolution routine: "
+            f"sense_index={sense_index} out of range; available senses={candidate_count}."
+        )
+    return idx
 
 
 def synset_to_payload(synset: Any) -> Dict[str, Any]:
@@ -89,11 +118,7 @@ def resolve_wordnet_synset(
         candidates = wn.synsets(lemma, pos=mapped_pos)
         if not candidates:
             raise LookupError(f"No synsets found for lemma={lemma!r}, pos={pos!r}")
-        idx = max(1, sense_index) - 1
-        if idx >= len(candidates):
-            raise LookupError(
-                f"sense_index={sense_index} out of range; available senses={len(candidates)}"
-            )
+        idx = _resolve_sense_index(sense_index, len(candidates))
         return synset_to_payload(candidates[idx])
 
     raise ValueError(

--- a/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
+++ b/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
@@ -39,8 +39,14 @@ def parse_eng30_id(english_id: str) -> Tuple[int, str]:
             f"parse_eng30_id: invalid selector {english_id!r}; expected 'ENG30-########-[n|v|a|s|r]'."
         )
 
+    offset_token = parts[1]
+    if len(offset_token) != 8 or not offset_token.isdigit():
+        raise ValueError(
+            f"parse_eng30_id: invalid offset in selector {english_id!r}; offset must be exactly 8 digits."
+        )
+
     try:
-        offset = int(parts[1])
+        offset = int(offset_token)
     except ValueError as exc:
         raise ValueError(
             f"parse_eng30_id: invalid offset in selector {english_id!r}; offset must be an integer."

--- a/tests/test_langgraph_pipeline.py
+++ b/tests/test_langgraph_pipeline.py
@@ -384,6 +384,33 @@ def test_call_llm_retries_on_invoke_exception():
     assert call["payload"]["sense_summary"] == "desc"
 
 
+def test_call_llm_fallback_payload_shape_after_repeated_invoke_exceptions():
+    class _AlwaysFailLLM:
+        def invoke(self, messages):
+            raise RuntimeError("transport down")
+
+    pipeline = LangGraphTranslationPipeline(
+        source_lang="en",
+        target_lang="sr",
+        llm=_AlwaysFailLLM(),
+    )
+
+    call = pipeline._call_llm("prompt", stage="sense_analysis", retries=1)
+    payload = call["payload"]
+
+    # Ensure fallback payload respects stage schema shape.
+    assert set(payload.keys()) == {
+        "sense_summary",
+        "contrastive_note",
+        "key_features",
+        "domain_tags",
+        "confidence",
+    }
+    assert isinstance(payload["key_features"], list)
+    assert isinstance(payload["domain_tags"], list)
+    assert call["raw_response"] == "transport down"
+
+
 def test_translation_result_to_dict():
     """Test TranslationResult.to_dict() serialization."""
     from wordnet_autotranslate.pipelines.langgraph_translation_pipeline import (

--- a/tests/test_langgraph_pipeline.py
+++ b/tests/test_langgraph_pipeline.py
@@ -1,4 +1,6 @@
 import json
+import sys
+import types
 from typing import List, Optional
 
 import pytest
@@ -303,6 +305,43 @@ def test_decode_llm_payload_invalid_json_fallback():
     # Should return the cleaned text as translation
     assert "translation" in result
     assert result["translation"] == raw
+
+
+def test_get_wordnet_domain_info_normalizes_serbian_adverb_pos(monkeypatch):
+    """Test ENG IDs using Serbian POS markers (b) are normalized to r."""
+
+    observed = {}
+
+    class _FakeTopicDomain:
+        def name(self):
+            return "topic.test.01"
+
+    class _FakeSynset:
+        def lexname(self):
+            return "adv.all"
+
+        def topic_domains(self):
+            return [_FakeTopicDomain()]
+
+    def _fake_lookup(pos_char, offset):
+        observed["pos_char"] = pos_char
+        observed["offset"] = offset
+        return _FakeSynset()
+
+    fake_wordnet = types.SimpleNamespace(synset_from_pos_and_offset=_fake_lookup)
+    fake_corpus = types.SimpleNamespace(wordnet=fake_wordnet)
+    fake_nltk = types.SimpleNamespace(corpus=fake_corpus)
+
+    monkeypatch.setitem(sys.modules, "nltk", fake_nltk)
+    monkeypatch.setitem(sys.modules, "nltk.corpus", fake_corpus)
+    monkeypatch.setitem(sys.modules, "nltk.corpus.wordnet", fake_wordnet)
+
+    result = LangGraphTranslationPipeline._get_wordnet_domain_info("ENG30-00001740-b")
+
+    assert observed["pos_char"] == "r"
+    assert observed["offset"] == 1740
+    assert result["lexname"] == "adv.all"
+    assert result["topic_domains"] == ["topic.test.01"]
 
 
 def test_translation_result_to_dict():

--- a/tests/test_langgraph_pipeline.py
+++ b/tests/test_langgraph_pipeline.py
@@ -307,6 +307,14 @@ def test_decode_llm_payload_invalid_json_fallback():
     assert result["translation"] == raw
 
 
+def test_coerce_to_str_list_ignores_non_strings():
+    result = LangGraphTranslationPipeline._coerce_to_str_list(
+        [" valid ", None, 7, {"x": 1}, "", "ok"]
+    )
+    assert result == ["valid", "ok"]
+    assert LangGraphTranslationPipeline._coerce_to_str_list({"bad": "shape"}) == []
+
+
 def test_get_wordnet_domain_info_normalizes_serbian_adverb_pos(monkeypatch):
     """Test ENG IDs using Serbian POS markers (b) are normalized to r."""
 
@@ -342,6 +350,38 @@ def test_get_wordnet_domain_info_normalizes_serbian_adverb_pos(monkeypatch):
     assert observed["offset"] == 1740
     assert result["lexname"] == "adv.all"
     assert result["topic_domains"] == ["topic.test.01"]
+
+
+def test_call_llm_retries_on_invoke_exception():
+    class _FailOnceLLM:
+        def __init__(self):
+            self.calls = 0
+
+        def invoke(self, messages):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("temporary transport failure")
+
+            class _Response:
+                content = json.dumps(
+                    {
+                        "sense_summary": "desc",
+                        "contrastive_note": "note",
+                        "key_features": ["f1"],
+                        "domain_tags": [],
+                        "confidence": "high",
+                    }
+                )
+
+            return _Response()
+
+    pipeline = LangGraphTranslationPipeline(
+        source_lang="en",
+        target_lang="sr",
+        llm=_FailOnceLLM(),
+    )
+    call = pipeline._call_llm("prompt", stage="sense_analysis", retries=1)
+    assert call["payload"]["sense_summary"] == "desc"
 
 
 def test_translation_result_to_dict():

--- a/tests/test_langgraph_pipeline.py
+++ b/tests/test_langgraph_pipeline.py
@@ -411,6 +411,56 @@ def test_call_llm_fallback_payload_shape_after_repeated_invoke_exceptions():
     assert call["raw_response"] == "transport down"
 
 
+@pytest.mark.parametrize(
+    ("stage", "expected_keys"),
+    [
+        (
+            "sense_analysis",
+            {
+                "sense_summary",
+                "contrastive_note",
+                "key_features",
+                "domain_tags",
+                "confidence",
+            },
+        ),
+        (
+            "definition_translation",
+            {"definition_translation", "notes", "examples"},
+        ),
+        (
+            "initial_translation",
+            {"initial_translations", "alignment"},
+        ),
+        (
+            "synonym_expansion",
+            {"expanded_synonyms", "rationale"},
+        ),
+        (
+            "synonym_filtering",
+            {"filtered_synonyms", "removed", "confidence"},
+        ),
+    ],
+)
+def test_call_llm_fallback_payload_shape_matrix_after_repeated_invoke_exceptions(
+    stage, expected_keys
+):
+    class _AlwaysFailLLM:
+        def invoke(self, messages):
+            raise RuntimeError(f"{stage} transport down")
+
+    pipeline = LangGraphTranslationPipeline(
+        source_lang="en",
+        target_lang="sr",
+        llm=_AlwaysFailLLM(),
+    )
+
+    call = pipeline._call_llm("prompt", stage=stage, retries=1)
+    payload = call["payload"]
+    assert set(payload.keys()) == expected_keys
+    assert call["raw_response"] == f"{stage} transport down"
+
+
 def test_translation_result_to_dict():
     """Test TranslationResult.to_dict() serialization."""
     from wordnet_autotranslate.pipelines.langgraph_translation_pipeline import (

--- a/tests/test_synset_translation_workflow.py
+++ b/tests/test_synset_translation_workflow.py
@@ -45,9 +45,21 @@ def test_parse_eng30_id_normalizes_adverb_pos():
     assert pos == "r"
 
 
+def test_parse_eng30_id_normalizes_satellite_adjective_pos():
+    offset, pos = parse_eng30_id("ENG30-00001740-s")
+
+    assert offset == 1740
+    assert pos == "a"
+
+
 def test_parse_eng30_id_rejects_malformed_selector():
     with pytest.raises(ValueError, match="parse_eng30_id"):
         parse_eng30_id("BROKEN-1740-x")
+
+
+def test_parse_eng30_id_rejects_invalid_pos_with_clear_message():
+    with pytest.raises(ValueError, match="expected one of n,v,a,s,r"):
+        parse_eng30_id("ENG30-00001740-x")
 
 
 def test_synset_to_payload_builds_expected_shape():

--- a/tests/test_synset_translation_workflow.py
+++ b/tests/test_synset_translation_workflow.py
@@ -6,6 +6,7 @@ from wordnet_autotranslate.workflows.synset_translation_workflow import (
     parse_eng30_id,
     run_translation_workflow,
     synset_to_payload,
+    _resolve_sense_index,
 )
 
 
@@ -44,6 +45,11 @@ def test_parse_eng30_id_normalizes_adverb_pos():
     assert pos == "r"
 
 
+def test_parse_eng30_id_rejects_malformed_selector():
+    with pytest.raises(ValueError, match="parse_eng30_id"):
+        parse_eng30_id("BROKEN-1740-x")
+
+
 def test_synset_to_payload_builds_expected_shape():
     payload = synset_to_payload(_FakeSynset())
 
@@ -72,6 +78,11 @@ def test_run_translation_workflow_dspy_reports_not_implemented():
 def test_run_translation_workflow_rejects_unknown_pipeline():
     with pytest.raises(ValueError, match="Unsupported pipeline"):
         run_translation_workflow({"id": "ENG30-00001740-n"}, pipeline="unknown")
+
+
+def test_resolve_sense_index_requires_positive_integer():
+    with pytest.raises(ValueError, match="sense-index resolution routine"):
+        _resolve_sense_index(0, 3)
 
 
 def test_run_translation_workflow_all_includes_dspy(monkeypatch):

--- a/tests/test_synset_translation_workflow.py
+++ b/tests/test_synset_translation_workflow.py
@@ -1,0 +1,72 @@
+import pytest
+
+from wordnet_autotranslate.workflows.synset_translation_workflow import (
+    parse_eng30_id,
+    run_translation_workflow,
+    synset_to_payload,
+)
+
+
+class _FakeLemma:
+    def __init__(self, name: str):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class _FakeSynset:
+    def offset(self):
+        return 1740
+
+    def pos(self):
+        return "n"
+
+    def name(self):
+        return "entity.n.01"
+
+    def definition(self):
+        return "that which is perceived or known to have its own distinct existence"
+
+    def examples(self):
+        return ["The entity is real."]
+
+    def lemmas(self):
+        return [_FakeLemma("entity"), _FakeLemma("physical_entity")]
+
+
+def test_parse_eng30_id_normalizes_adverb_pos():
+    offset, pos = parse_eng30_id("ENG30-00001740-b")
+
+    assert offset == 1740
+    assert pos == "r"
+
+
+def test_synset_to_payload_builds_expected_shape():
+    payload = synset_to_payload(_FakeSynset())
+
+    assert payload["id"] == "ENG30-00001740-n"
+    assert payload["name"] == "entity.n.01"
+    assert payload["lemmas"] == ["entity", "physical entity"]
+    assert payload["pos"] == "n"
+
+
+def test_run_translation_workflow_dspy_reports_not_implemented():
+    result = run_translation_workflow(
+        {
+            "id": "ENG30-00001740-n",
+            "lemmas": ["entity"],
+            "definition": "something that exists",
+            "examples": [],
+            "pos": "n",
+        },
+        pipeline="dspy",
+    )
+
+    assert "dspy" in result["pipelines"]
+    assert result["pipelines"]["dspy"]["status"] == "not_implemented"
+
+
+def test_run_translation_workflow_rejects_unknown_pipeline():
+    with pytest.raises(ValueError, match="Unsupported pipeline"):
+        run_translation_workflow({"id": "ENG30-00001740-n"}, pipeline="unknown")

--- a/tests/test_synset_translation_workflow.py
+++ b/tests/test_synset_translation_workflow.py
@@ -1,6 +1,8 @@
 import pytest
 
+from wordnet_autotranslate.workflows import synset_translation_workflow as workflow_mod
 from wordnet_autotranslate.workflows.synset_translation_workflow import (
+    WorkflowConfig,
     parse_eng30_id,
     run_translation_workflow,
     synset_to_payload,
@@ -70,3 +72,65 @@ def test_run_translation_workflow_dspy_reports_not_implemented():
 def test_run_translation_workflow_rejects_unknown_pipeline():
     with pytest.raises(ValueError, match="Unsupported pipeline"):
         run_translation_workflow({"id": "ENG30-00001740-n"}, pipeline="unknown")
+
+
+def test_run_translation_workflow_all_includes_dspy(monkeypatch):
+    class _FakeLangGraph:
+        def __init__(self, **kwargs):
+            pass
+
+        def translate_synset(self, synset):
+            return {"translation": "lg"}
+
+    class _FakeConceptual:
+        def __init__(self, **kwargs):
+            pass
+
+        def translate_synset(self, synset):
+            return {"translation": "cg"}
+
+    monkeypatch.setattr(workflow_mod, "LangGraphTranslationPipeline", _FakeLangGraph)
+    monkeypatch.setattr(
+        workflow_mod, "ConceptualLangGraphTranslationPipeline", _FakeConceptual
+    )
+
+    result = run_translation_workflow({"id": "ENG30-00001740-n"}, pipeline="all")
+    assert set(result["pipelines"]) == {"langgraph", "conceptual", "dspy"}
+
+
+def test_run_translation_workflow_capture_errors_when_non_strict(monkeypatch):
+    class _FailingLangGraph:
+        def __init__(self, **kwargs):
+            pass
+
+        def translate_synset(self, synset):
+            raise RuntimeError("llm unavailable")
+
+    monkeypatch.setattr(
+        workflow_mod, "LangGraphTranslationPipeline", _FailingLangGraph
+    )
+    result = run_translation_workflow(
+        {"id": "ENG30-00001740-n"},
+        pipeline="langgraph",
+        config=WorkflowConfig(strict=False),
+    )
+    assert result["pipelines"]["langgraph"]["status"] == "error"
+
+
+def test_run_translation_workflow_raises_when_strict(monkeypatch):
+    class _FailingLangGraph:
+        def __init__(self, **kwargs):
+            pass
+
+        def translate_synset(self, synset):
+            raise RuntimeError("llm unavailable")
+
+    monkeypatch.setattr(
+        workflow_mod, "LangGraphTranslationPipeline", _FailingLangGraph
+    )
+    with pytest.raises(RuntimeError, match="llm unavailable"):
+        run_translation_workflow(
+            {"id": "ENG30-00001740-n"},
+            pipeline="langgraph",
+            config=WorkflowConfig(strict=True),
+        )

--- a/tests/test_synset_translation_workflow.py
+++ b/tests/test_synset_translation_workflow.py
@@ -52,6 +52,13 @@ def test_parse_eng30_id_normalizes_satellite_adjective_pos():
     assert pos == "a"
 
 
+def test_parse_eng30_id_passes_through_adjective_pos():
+    offset, pos = parse_eng30_id("ENG30-00001740-a")
+
+    assert offset == 1740
+    assert pos == "a"
+
+
 def test_parse_eng30_id_rejects_malformed_selector():
     with pytest.raises(ValueError, match="parse_eng30_id"):
         parse_eng30_id("BROKEN-1740-x")
@@ -60,6 +67,44 @@ def test_parse_eng30_id_rejects_malformed_selector():
 def test_parse_eng30_id_rejects_invalid_pos_with_clear_message():
     with pytest.raises(ValueError, match="expected one of n,v,a,s,r"):
         parse_eng30_id("ENG30-00001740-x")
+
+
+def test_parse_eng30_id_rejects_malformed_offset_length():
+    with pytest.raises(ValueError, match="exactly 8 digits"):
+        parse_eng30_id("ENG30-1740-n")
+
+
+def test_parse_eng30_id_rejects_malformed_offset_characters():
+    with pytest.raises(ValueError, match="exactly 8 digits"):
+        parse_eng30_id("ENG30-00A01740-n")
+
+
+def test_parse_eng30_id_seed_fuzz_corpus():
+    valid_selectors = [
+        "ENG30-00001740-n",
+        "ENG30-00001740-v",
+        "ENG30-00001740-a",
+        "ENG30-00001740-s",
+        "ENG30-00001740-r",
+        "ENG30-00001740-b",
+    ]
+    invalid_selectors = [
+        "ENG30-1740-n",
+        "ENG30-00A01740-n",
+        "BROKEN-00001740-n",
+        "ENG30-00001740-x",
+        "ENG30--n",
+        "ENG30-00001740",
+    ]
+
+    for selector in valid_selectors:
+        offset, pos = parse_eng30_id(selector)
+        assert isinstance(offset, int)
+        assert pos in {"n", "v", "a", "r"}
+
+    for selector in invalid_selectors:
+        with pytest.raises(ValueError):
+            parse_eng30_id(selector)
 
 
 def test_synset_to_payload_builds_expected_shape():

--- a/tests/test_synset_translation_workflow.py
+++ b/tests/test_synset_translation_workflow.py
@@ -1,4 +1,6 @@
 import pytest
+import random
+import string
 
 from wordnet_autotranslate.workflows import synset_translation_workflow as workflow_mod
 from wordnet_autotranslate.workflows.synset_translation_workflow import (
@@ -101,6 +103,77 @@ def test_parse_eng30_id_seed_fuzz_corpus():
         offset, pos = parse_eng30_id(selector)
         assert isinstance(offset, int)
         assert pos in {"n", "v", "a", "r"}
+
+    for selector in invalid_selectors:
+        with pytest.raises(ValueError):
+            parse_eng30_id(selector)
+
+
+@pytest.mark.parametrize(
+    ("selector", "expected_pos"),
+    [
+        ("ENG30-00001740-N", "n"),
+        ("ENG30-00001740-V", "v"),
+        ("ENG30-00001740-A", "a"),
+        ("ENG30-00001740-S", "a"),
+        ("ENG30-00001740-R", "r"),
+        ("ENG30-00001740-B", "r"),
+    ],
+)
+def test_parse_eng30_id_uppercase_pos_inputs(selector, expected_pos):
+    offset, pos = parse_eng30_id(selector)
+    assert offset == 1740
+    assert pos == expected_pos
+
+
+@pytest.mark.parametrize(
+    ("selector", "expected_pos"),
+    [
+        ("ENG30-00001740-n", "n"),
+        ("ENG30-00001740-v", "v"),
+        ("ENG30-00001740-a", "a"),
+        ("ENG30-00001740-s", "a"),
+        ("ENG30-00001740-r", "r"),
+        ("ENG30-00001740-b", "r"),
+    ],
+)
+def test_parse_eng30_id_allowed_pos_table(selector, expected_pos):
+    offset, pos = parse_eng30_id(selector)
+    assert offset == 1740
+    assert pos == expected_pos
+
+
+def test_parse_eng30_id_generated_fuzz_cases():
+    rng = random.Random(1337)
+    delimiters = ["_", "/", "—", " "]
+
+    invalid_selectors = []
+    # Random wrong delimiters, malformed offsets, and invalid POS tokens.
+    for _ in range(40):
+        delim = rng.choice(delimiters)
+        offset_len = rng.choice([1, 2, 3, 4, 5, 6, 7, 9, 10])
+        offset = "".join(rng.choice(string.digits) for _ in range(offset_len))
+        pos = rng.choice([ch for ch in (string.ascii_letters + "!?") if ch.lower() not in "nvasrb"])
+        parts = ["ENG30", offset, pos]
+        if rng.random() < 0.5:
+            parts.append("extra")
+        invalid_selectors.append(delim.join(parts))
+
+    # Unicode/punctuation noise and partial tokens.
+    invalid_selectors.extend(
+        [
+            "ENG30-00001740-ñ",
+            "ENG30-００００１７４０-n",  # full-width digits
+            "ENG30-00001740-",
+            "ENG30-0000174-n",  # short offset
+            "ENG30-000017400-n",  # long offset
+            "ENG30-0000A740-n",
+            "ENG30-💥-n",
+            "ENG30-n",
+            "ENG30--",
+            "ENG3O-00001740-n",  # letter O in prefix
+        ]
+    )
 
     for selector in invalid_selectors:
         with pytest.raises(ValueError):

--- a/tests/test_translate_synset_cli.py
+++ b/tests/test_translate_synset_cli.py
@@ -1,0 +1,28 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "translate_synset_workflow.py"
+
+_spec = importlib.util.spec_from_file_location("translate_synset_workflow", SCRIPT_PATH)
+cli = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(cli)
+
+
+def test_cli_requires_pos_with_lemma(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["prog", "--lemma", "entity"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+
+
+def test_cli_keyboard_interrupt_returns_130(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["prog", "--english-id", "ENG30-00001740-n"])
+
+    def _raise_interrupt(**kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli, "resolve_wordnet_synset", _raise_interrupt)
+    assert cli.main() == 130


### PR DESCRIPTION
### Motivation

- Provide an agent-compatible, repeatable workflow for translating English WordNet synsets (by ENG30 id, synset name, or lemma+POS) and expose it via a small CLI and skill documentation. 
- Improve robustness of the LangGraph pipeline when calling LLMs and assembling results, handling malformed/empty LLM output and normalizing varied payload types. 
- Surface workflow utilities from the package root and update project metadata to match desired licensing.

### Description

- Added an agent-oriented workflow module `src/wordnet_autotranslate/workflows/synset_translation_workflow.py` with `WorkflowConfig`, `resolve_wordnet_synset`, `run_translation_workflow`, `parse_eng30_id`, `synset_to_payload`, and `results_to_json` utilities. 
- Added CLI wrapper `scripts/translate_synset_workflow.py` for invoking the workflow from the command line and a skill document `skills/translate-synset-serbian/SKILL.md` describing agent usage. 
- Exported workflow helpers via `src/wordnet_autotranslate/workflows/__init__.py` and added them to the package `__init__.py` exports. 
- Hardened `LangGraphTranslationPipeline` (`src/wordnet_autotranslate/pipelines/langgraph_translation_pipeline.py`) by improving `_call_llm` (better system prompt handling, raw capture, validated fallback payload), normalizing POS handling using `LanguageUtils.normalize_pos_for_english`, adding `_coerce_to_str_list` helper for consistent list/string handling, and using it when assembling final results. 
- Updated `README.md` with an example CLI usage and a pointer to the skill documentation and added a short license change in `pyproject.toml` from MIT to `CC0-1.0` with corresponding classifier adjustments. 
- Added unit tests: extended `tests/test_langgraph_pipeline.py` with a normalization test and added `tests/test_synset_translation_workflow.py` covering `parse_eng30_id`, `synset_to_payload`, `run_translation_workflow` behavior, and error cases.

### Testing

- Ran the unit test suite with `pytest` covering the modified pipeline tests and new workflow tests, and all tests completed successfully. 
- Exercised `run_translation_workflow` paths including `pipeline="dspy"` not-implemented response and unknown-pipeline rejection via `tests/test_synset_translation_workflow.py`, and verified the POS normalization test `test_get_wordnet_domain_info_normalizes_serbian_adverb_pos` in `tests/test_langgraph_pipeline.py` passed. 
- No integration tests against an actual Ollama/LLM endpoint were run as part of this change; CLI and workflow outputs are serialized to JSON for downstream tools.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca661b4254832991970569c1881dd0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI to translate English WordNet synsets with selectable pipelines, model/connectivity options, language controls, and strict/error modes.
  * Public workflow API exports to build and run synset translation workflows and serialize results.

* **Documentation**
  * README, AGENTS, and skill docs updated with workflow description, CLI examples, selector options, and usage notes.

* **Chores**
  * Project license changed from MIT to CC0-1.0; minor config newline fix.

* **Tests**
  * New unit and CLI tests covering parsing, payloads, pipelines, retries, and error/exit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->