### PR TITLE
Add stage schema validation, LLM retries/observability, CLI selector checks, and CI/security workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   pull_request:
   push:
@@ -14,7 +17,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -35,7 +38,7 @@ jobs:
   dependency-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, master, work]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Format check
+        run: python -m black --check src tests scripts
+
+      - name: Run tests
+        run: PYTHONPATH=src pytest -q
+
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install audit tool
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pip-audit
+      - name: Audit dependencies
+        run: pip-audit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,16 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main, master, work]
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,8 @@
 name: Security
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   pull_request:
   push:
@@ -9,8 +12,21 @@ jobs:
   secret-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v5
+
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION="8.24.3"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz
+          sudo mv gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Run gitleaks scan
+        run: |
+          gitleaks detect \
+            --source . \
+            --config .gitleaks.toml \
+            --report-format json \
+            --report-path gitleaks-report.json \
+            --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+title = "wordnet_autotranslate gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known non-secret generated/demo content and notebooks"
+paths = [
+  '''(^|/)notebooks/''',
+  '''(^|/)examples/''',
+  '''(^|/)demo_gui\.html$''',
+  '''(^|/)translation_graph\.(png|txt|mmd)$''',
+]

--- a/README.md
+++ b/README.md
@@ -139,7 +139,15 @@ resolution and single/multi-pipeline execution), use:
 python scripts/translate_synset_workflow.py --english-id ENG30-00001740-n --pipeline all --model gpt-oss:120b
 ```
 
+Selector families are mutually exclusive: provide exactly one of
+`--english-id`, `--synset-name`, or `--lemma` + `--pos`. If multiple are
+provided (or none), the CLI fails fast with a usage error.
+
 Use `--strict` to fail fast when any selected pipeline errors.
+Use `--timeout 1800` (default) for local long-running prompts on large models,
+and increase up to 3600 seconds when needed.
+Use `--max-retries` and `--retry-delay-seconds` to bound retry behavior for
+temporary local LLM/network failures.
 
 Skill documentation for agents is available at:
 `skills/translate-synset-serbian/SKILL.md`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,5 @@ When reporting, include:
 - Keep dependency versions pinned/minimum-bounded and run dependency audits
   regularly.
 - CI includes secret scanning and dependency auditing workflows.
+- Secret scanning uses `.gitleaks.toml` to ignore generated/non-sensitive
+  fixture directories while still enforcing leaks in source and config files.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+This repository is currently pre-1.0 (`0.1.x`). Security fixes are applied to
+the latest commit on the default branch.
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately to the maintainers by opening a
+**private security advisory** on GitHub (preferred). If that is unavailable,
+open an issue with minimal details and ask maintainers for a private channel.
+
+When reporting, include:
+- Affected files/components.
+- Reproduction steps and expected impact.
+- Suggested mitigation (if known).
+
+## Secrets and Sensitive Data
+
+- Never commit `.env` files, API keys, or tokens.
+- Do not include prompts/responses containing secrets in shared logs.
+- Rotate any secret immediately if exposure is suspected.
+
+## Secure Development Notes
+
+- Translation pipeline calls to external/local LLMs should use bounded retries
+  and explicit timeouts.
+- Keep dependency versions pinned/minimum-bounded and run dependency audits
+  regularly.
+- CI includes secret scanning and dependency auditing workflows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "pyyaml>=6.0",
     "python-dotenv>=1.0.0",
     "loguru>=0.7.0",
+    "pydantic>=2.7.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/translate_synset_workflow.py
+++ b/scripts/translate_synset_workflow.py
@@ -12,15 +12,25 @@ from wordnet_autotranslate.workflows.synset_translation_workflow import (
     results_to_json,
     run_translation_workflow,
 )
+from wordnet_autotranslate.workflows.selector_validation import (
+    validate_selector_families,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Translate an English WordNet synset to Serbian.")
+    parser = argparse.ArgumentParser(
+        description="Translate an English WordNet synset to Serbian."
+    )
     parser.add_argument("--english-id", help="ENG30 ID (e.g., ENG30-00001740-n)")
     parser.add_argument("--synset-name", help="WordNet synset name (e.g., entity.n.01)")
     parser.add_argument("--lemma", help="English lemma (requires --pos)")
     parser.add_argument("--pos", help="POS tag: n|v|a|r (Serbian b is accepted)")
-    parser.add_argument("--sense-index", type=int, default=1, help="1-based sense index for lemma lookup")
+    parser.add_argument(
+        "--sense-index",
+        type=int,
+        default=1,
+        help="1-based sense index for lemma lookup",
+    )
 
     parser.add_argument(
         "--pipeline",
@@ -29,16 +39,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="Pipeline(s) to run",
     )
     parser.add_argument("--model", default="gpt-oss:120b", help="Ollama model name")
-    parser.add_argument("--base-url", default="http://localhost:11434", help="Ollama base URL")
+    parser.add_argument(
+        "--base-url", default="http://localhost:11434", help="Ollama base URL"
+    )
     parser.add_argument("--source-lang", default="en")
     parser.add_argument("--target-lang", default="sr")
-    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=1800,
+        help="Per-request timeout in seconds (30-3600; default 1800 for local long prompts).",
+    )
     parser.add_argument("--temperature", type=float, default=0.2)
     parser.add_argument(
         "--strict",
         action="store_true",
         help="Fail immediately if any selected pipeline errors.",
     )
+    parser.add_argument("--max-retries", type=int, default=2)
+    parser.add_argument("--retry-delay-seconds", type=float, default=1.0)
     return parser
 
 
@@ -48,6 +67,17 @@ def main() -> int:
 
     if args.lemma and not args.pos:
         parser.error("--lemma requires --pos")
+    try:
+        validate_selector_families(
+            english_id=args.english_id,
+            synset_name=args.synset_name,
+            lemma=args.lemma,
+            pos=args.pos,
+        )
+    except ValueError:
+        parser.error(
+            "provide exactly one selector: --english-id OR --synset-name OR --lemma + --pos"
+        )
 
     try:
         synset_payload = resolve_wordnet_synset(
@@ -64,6 +94,8 @@ def main() -> int:
             timeout=args.timeout,
             base_url=args.base_url,
             temperature=args.temperature,
+            max_retries=args.max_retries,
+            retry_delay_seconds=args.retry_delay_seconds,
             strict=args.strict,
         )
         result = run_translation_workflow(

--- a/src/wordnet_autotranslate/pipelines/conceptual_langgraph_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/conceptual_langgraph_pipeline.py
@@ -26,10 +26,8 @@ from typing import Any, Dict, Generator, Iterable, List, Sequence, TypedDict
 from pydantic import BaseModel, Field
 
 from ..utils.language_utils import LanguageUtils
-from .langgraph_translation_pipeline import (
-    LangGraphTranslationPipeline,
-    validate_stage_payload,
-)
+from .langgraph_translation_pipeline import LangGraphTranslationPipeline
+from .stages.schema_validation import validate_stage_payload
 
 
 class RelatedSynsetSchema(BaseModel):
@@ -392,7 +390,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
         """Render the prompt for the expanded English definition stage."""
 
         concept_json = self._to_pretty_json(concept_package)
-        return textwrap.dedent(f"""
+        return textwrap.dedent(
+            f"""
             Create an expanded English semantic definition for a WordNet synset.
 
             Rules:
@@ -411,7 +410,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
 
             Concept package:
             {concept_json}
-            """).strip()
+            """
+        ).strip()
 
     def _render_expanded_definition_sr_prompt(
         self,
@@ -422,7 +422,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
 
         concept_json = self._to_pretty_json(concept_package)
         expanded_en_json = self._to_pretty_json(expanded_en)
-        return textwrap.dedent(f"""
+        return textwrap.dedent(
+            f"""
             Translate and adapt the expanded English semantic definition into Serbian.
 
             Rules:
@@ -444,7 +445,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
 
             Expanded English output:
             {expanded_en_json}
-            """).strip()
+            """
+        ).strip()
 
     def _render_literal_candidates_prompt(
         self,
@@ -455,7 +457,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
 
         concept_json = self._to_pretty_json(concept_package)
         expanded_sr_json = self._to_pretty_json(expanded_sr)
-        return textwrap.dedent(f"""
+        return textwrap.dedent(
+            f"""
             Propose Serbian literal candidates for a Serbian WordNet synset.
 
             Rules:
@@ -484,7 +487,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
 
             Expanded Serbian output:
             {expanded_sr_json}
-            """).strip()
+            """
+        ).strip()
 
     def _render_literal_selection_prompt(
         self,
@@ -497,7 +501,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
         concept_json = self._to_pretty_json(concept_package)
         expanded_sr_json = self._to_pretty_json(expanded_sr)
         candidates_json = self._to_pretty_json(literal_candidates)
-        return textwrap.dedent(f"""
+        return textwrap.dedent(
+            f"""
             Select the final Serbian literals for this WordNet synset.
 
             Rules:
@@ -520,7 +525,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
 
             Candidate literals:
             {candidates_json}
-            """).strip()
+            """
+        ).strip()
 
     def _render_final_gloss_prompt(
         self,
@@ -533,7 +539,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
         concept_json = self._to_pretty_json(concept_package)
         expanded_sr_json = self._to_pretty_json(expanded_sr)
         selection_json = self._to_pretty_json(selection)
-        return textwrap.dedent(f"""
+        return textwrap.dedent(
+            f"""
             Write a final short Serbian WordNet gloss.
 
             Rules:
@@ -556,7 +563,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
 
             Selected literals:
             {selection_json}
-            """).strip()
+            """
+        ).strip()
 
     def _render_validation_prompt(
         self,
@@ -571,7 +579,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
         expanded_sr_json = self._to_pretty_json(expanded_sr)
         selection_json = self._to_pretty_json(selection)
         final_gloss_json = self._to_pretty_json(final_gloss)
-        return textwrap.dedent(f"""
+        return textwrap.dedent(
+            f"""
             Validate a drafted Serbian WordNet synset.
 
             Check:
@@ -605,7 +614,8 @@ class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
 
             Final gloss:
             {final_gloss_json}
-            """).strip()
+            """
+        ).strip()
 
     def _assemble_result(
         self, state: ConceptualTranslationGraphState

--- a/src/wordnet_autotranslate/pipelines/langgraph_translation_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/langgraph_translation_pipeline.py
@@ -30,13 +30,13 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass
+import time
 import textwrap
 from typing import Any, Dict, Generator, Iterable, List, Optional, Sequence, TypedDict
 
-from pydantic import BaseModel, Field, ValidationError
-from pydantic_core import PydanticUndefined
-
+from .stages.schema_validation import BASE_STAGE_SCHEMA_MAP, validate_stage_payload
 from ..utils.language_utils import LanguageUtils
+from ..utils.observability import ensure_request_id, get_structured_logger, log_event
 
 
 class TranslationGraphState(TypedDict, total=False):
@@ -45,12 +45,12 @@ class TranslationGraphState(TypedDict, total=False):
     synset: Dict[str, Any]
     sense_analysis: Dict[str, Any]
     definition_translation: Dict[str, Any]
-    
+
     # New keys for multi-step synonym translation (generate-and-filter approach)
     initial_translation_call: Dict[str, Any]
     expansion_call: Dict[str, Any]
     filtering_call: Dict[str, Any]
-    
+
     result: Dict[str, Any]
 
 
@@ -70,8 +70,12 @@ class TranslationResult:
     payload: Dict[str, Any]
     curator_summary: str
     # English WordNet domain information (automatically fetched from NLTK)
-    lexname: Optional[str] = None  # Broad lexical category (e.g., "noun.artifact", "verb.motion")
-    topic_domains: Optional[List[str]] = None  # Semantic field markers (e.g., ["biochemistry.n.01"])
+    lexname: Optional[str] = (
+        None  # Broad lexical category (e.g., "noun.artifact", "verb.motion")
+    )
+    topic_domains: Optional[List[str]] = (
+        None  # Semantic field markers (e.g., ["biochemistry.n.01"])
+    )
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a serialisable representation for downstream usage."""
@@ -90,78 +94,6 @@ class TranslationResult:
             "lexname": self.lexname,
             "topic_domains": self.topic_domains,
         }
-
-
-# ==============================================================
-# Schema validation helpers for LangGraphTranslationPipeline
-# ==============================================================
-
-class SenseAnalysisSchema(BaseModel):
-    """Pydantic schema for sense analysis stage output."""
-    sense_summary: str = Field(..., min_length=3)
-    contrastive_note: Optional[str] = None
-    key_features: List[str] = Field(default_factory=list)
-    domain_tags: Optional[List[str]] = Field(default_factory=list)
-    confidence: str
-
-
-class DefinitionTranslationSchema(BaseModel):
-    """Pydantic schema for definition translation stage output."""
-    definition_translation: str
-    notes: Optional[str] = None
-    examples: Optional[List[str]] = Field(default_factory=list)
-
-
-class LemmaTranslationSchema(BaseModel):
-    """Pydantic schema for initial lemma translation stage output."""
-    initial_translations: List[Optional[str]]
-    alignment: Dict[str, Optional[str]]
-
-
-class ExpansionSchema(BaseModel):
-    """Pydantic schema for synonym expansion stage output."""
-    expanded_synonyms: List[str]
-    rationale: Optional[Dict[str, str]] = Field(default_factory=dict)
-
-
-class FilteringSchema(BaseModel):
-    """Pydantic schema for synonym filtering stage output."""
-    filtered_synonyms: List[str]
-    removed: Optional[List[Dict[str, str]]] = Field(default_factory=list)
-    confidence: str
-
-
-def validate_stage_payload(payload: dict, schema_cls: type[BaseModel], stage_name: str) -> dict:
-    """Validate LLM JSON payload against the expected schema.
-    
-    Auto-repairs empty or malformed values and logs warnings.
-    
-    Args:
-        payload: Raw dictionary from LLM output.
-        schema_cls: Pydantic model class to validate against.
-        stage_name: Stage name for logging.
-        
-    Returns:
-        Validated and potentially repaired payload dictionary.
-    """
-    try:
-        model = schema_cls(**payload)
-        return model.model_dump()
-    except ValidationError as e:
-        print(f"[WARN] Validation failed for stage '{stage_name}': {e}")
-        # Return fallback with required keys if possible
-        fallback = {}
-        for field_name, field_info in schema_cls.model_fields.items():
-            if field_info.is_required():
-                fallback[field_name] = ""
-            elif field_info.default is not PydanticUndefined:
-                fallback[field_name] = field_info.default
-            elif field_info.default_factory is not None:
-                # Call the factory function to get default value
-                fallback[field_name] = field_info.default_factory()
-            else:
-                fallback[field_name] = None
-        return {**fallback, **payload}
 
 
 class LangGraphTranslationPipeline:
@@ -188,9 +120,11 @@ class LangGraphTranslationPipeline:
 
     # Response preview limit for logging
     _PREVIEW_LIMIT: int = 600
-    
+
     # Maximum number of synonyms to display in summary
     _MAX_SYNONYMS_DISPLAY: int = 5
+    DEFAULT_TIMEOUT: int = 1800
+    MAX_TIMEOUT: int = 3600
 
     def __init__(
         self,
@@ -199,7 +133,10 @@ class LangGraphTranslationPipeline:
         model: str = "gpt-oss:120b",
         temperature: float = 0.2,
         base_url: str = "http://localhost:11434",
-        timeout: int = 600,
+        timeout: int = DEFAULT_TIMEOUT,
+        max_retries: int = 2,
+        retry_delay_seconds: float = 1.0,
+        request_id: Optional[str] = None,
         system_prompt: Optional[str] = None,
         prompt_template: Optional[str] = None,
         llm: Optional[Any] = None,
@@ -209,7 +146,12 @@ class LangGraphTranslationPipeline:
         self.model = model
         self.temperature = temperature
         self.base_url = base_url
-        self.timeout = timeout
+        bounded_timeout = max(30, min(int(timeout), self.MAX_TIMEOUT))
+        self.timeout = bounded_timeout
+        self.max_retries = max(0, int(max_retries))
+        self.retry_delay_seconds = max(0.0, float(retry_delay_seconds))
+        self.request_id = ensure_request_id(request_id)
+        self.logger = get_structured_logger("wordnet_autotranslate.pipeline")
         self.system_prompt = system_prompt or self.DEFAULT_SYSTEM_PROMPT
         self.prompt_template = prompt_template or self.DEFAULT_PROMPT_TEMPLATE
 
@@ -222,11 +164,15 @@ class LangGraphTranslationPipeline:
             chat_factory,
         ) = self._load_dependencies(llm)
 
-        self.llm = llm if llm is not None else chat_factory(
-            model=self.model,
-            temperature=self.temperature,
-            timeout=self.timeout,
-            base_url=self.base_url,
+        self.llm = (
+            llm
+            if llm is not None
+            else chat_factory(
+                model=self.model,
+                temperature=self.temperature,
+                timeout=self.timeout,
+                base_url=self.base_url,
+            )
         )
 
         self._graph = self._build_graph()
@@ -261,7 +207,7 @@ class LangGraphTranslationPipeline:
 
     def _build_graph(self) -> Any:
         """Build and compile the LangGraph state machine for translation.
-        
+
         The graph now uses a multi-step synonym translation approach:
         1. analyse_sense - Understand semantic features
         2. translate_definition - Translate the definition
@@ -269,7 +215,7 @@ class LangGraphTranslationPipeline:
         4. expand_synonyms - Broaden the candidate pool
         5. filter_synonyms - Quality check and validation
         6. assemble_result - Combine all outputs
-        
+
         Returns:
             Compiled graph ready for invocation.
         """
@@ -293,9 +239,21 @@ class LangGraphTranslationPipeline:
 
     def translate_synset(self, synset: Dict[str, Any]) -> Dict[str, Any]:
         """Translate a single synset and return a structured dictionary."""
-
+        log_event(
+            self.logger,
+            event="translation_started",
+            request_id=self.request_id,
+            synset_id=synset.get("id") or synset.get("english_id"),
+        )
         state = self._graph.invoke({"synset": synset})
         result: TranslationResult = state["result"]  # type: ignore[index]
+        log_event(
+            self.logger,
+            event="translation_completed",
+            request_id=self.request_id,
+            synset_id=synset.get("id") or synset.get("english_id"),
+            translated_synonyms=len(result.translated_synonyms),
+        )
         return result.to_dict()
 
     def translate(self, synsets: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -317,10 +275,10 @@ class LangGraphTranslationPipeline:
 
     def _analyse_sense(self, state: TranslationGraphState) -> TranslationGraphState:
         """LangGraph node: Analyse synset sense before translation.
-        
+
         Args:
             state: Current graph state containing synset data.
-            
+
         Returns:
             Updated state with sense_analysis results.
         """
@@ -329,12 +287,14 @@ class LangGraphTranslationPipeline:
         call_result = self._call_llm(prompt, stage="sense_analysis")
         return {"sense_analysis": call_result}
 
-    def _translate_definition(self, state: TranslationGraphState) -> TranslationGraphState:
+    def _translate_definition(
+        self, state: TranslationGraphState
+    ) -> TranslationGraphState:
         """LangGraph node: Translate synset definition.
-        
+
         Args:
             state: Current graph state with sense analysis.
-            
+
         Returns:
             Updated state with definition_translation results.
         """
@@ -344,15 +304,17 @@ class LangGraphTranslationPipeline:
         call_result = self._call_llm(prompt, stage="definition_translation")
         return {"definition_translation": call_result}
 
-    def _translate_all_lemmas(self, state: TranslationGraphState) -> TranslationGraphState:
+    def _translate_all_lemmas(
+        self, state: TranslationGraphState
+    ) -> TranslationGraphState:
         """LangGraph node: Translate all English lemmas directly.
-        
+
         This is the first step in the multi-step synonym pipeline. It gets
         initial direct translations for each English lemma in the source synset.
-        
+
         Args:
             state: Current graph state with synset and sense_analysis.
-            
+
         Returns:
             Updated state with initial_translation_call results.
         """
@@ -364,41 +326,45 @@ class LangGraphTranslationPipeline:
 
     def _expand_synonyms(self, state: TranslationGraphState) -> TranslationGraphState:
         """LangGraph node: Expand the candidate pool with additional synonyms.
-        
+
         This is the second step in the multi-step synonym pipeline. It takes
         the initial translations and finds more synonyms in the target language
         that align with the sense and definition.
-        
+
         Args:
             state: Current graph state with initial translations.
-            
+
         Returns:
             Updated state with expansion_call results.
         """
         initial_payload = state.get("initial_translation_call", {}).get("payload", {})
         sense_payload = state.get("sense_analysis", {}).get("payload", {})
         definition_payload = state.get("definition_translation", {}).get("payload", {})
-        prompt = self._render_expansion_prompt(initial_payload, sense_payload, definition_payload)
+        prompt = self._render_expansion_prompt(
+            initial_payload, sense_payload, definition_payload
+        )
         call_result = self._call_llm(prompt, stage="synonym_expansion")
         return {"expansion_call": call_result}
 
     def _filter_synonyms(self, state: TranslationGraphState) -> TranslationGraphState:
         """LangGraph node: Filter and validate synonym candidates.
-        
+
         This is the final step in the multi-step synonym pipeline. It performs
         a quality check to remove candidates that don't precisely match the
         intended sense, ensuring high-quality output.
-        
+
         Args:
             state: Current graph state with expanded synonyms.
-            
+
         Returns:
             Updated state with filtering_call results.
         """
         expansion_payload = state.get("expansion_call", {}).get("payload", {})
         sense_payload = state.get("sense_analysis", {}).get("payload", {})
         definition_payload = state.get("definition_translation", {}).get("payload", {})
-        prompt = self._render_filtering_prompt(expansion_payload, sense_payload, definition_payload)
+        prompt = self._render_filtering_prompt(
+            expansion_payload, sense_payload, definition_payload
+        )
         call_result = self._call_llm(prompt, stage="synonym_filtering")
         return {"filtering_call": call_result}
 
@@ -411,23 +377,31 @@ class LangGraphTranslationPipeline:
 
     def _render_sense_prompt(self, synset: Dict[str, Any]) -> str:
         """Generate prompt for sense analysis stage (improved with contrastive notes).
-        
+
         Args:
             synset: Source synset with lemmas, definition, examples.
-            
+
         Returns:
             Formatted prompt for LLM.
         """
         lemmas = synset.get("lemmas") or synset.get("literals") or []
-        lemmas_str = ", ".join(lemmas) if isinstance(lemmas, (list, tuple)) else str(lemmas)
+        lemmas_str = (
+            ", ".join(lemmas) if isinstance(lemmas, (list, tuple)) else str(lemmas)
+        )
 
         definition = synset.get("definition") or synset.get("gloss") or ""
         examples = synset.get("examples") or []
-        examples_str = "\n- ".join(str(ex) for ex in examples) if examples else "(no examples)"
+        examples_str = (
+            "\n- ".join(str(ex) for ex in examples) if examples else "(no examples)"
+        )
 
         pos = synset.get("pos") or synset.get("part_of_speech") or ""
-        normalized_pos = LanguageUtils.normalize_pos_for_english(str(pos)) if pos else ""
-        english_id = synset.get("id") or synset.get("english_id") or synset.get("ili_id") or ""
+        normalized_pos = (
+            LanguageUtils.normalize_pos_for_english(str(pos)) if pos else ""
+        )
+        english_id = (
+            synset.get("id") or synset.get("english_id") or synset.get("ili_id") or ""
+        )
 
         # Fetch domain information from English WordNet
         domain_info = self._get_wordnet_domain_info(english_id)
@@ -468,11 +442,11 @@ class LangGraphTranslationPipeline:
         sense_payload: Dict[str, Any],
     ) -> str:
         """Generate prompt for definition translation stage (improved: concise gloss style + fallback rules).
-        
+
         Args:
             synset: Source synset data.
             sense_payload: Output from sense analysis stage.
-            
+
         Returns:
             Formatted prompt for LLM.
         """
@@ -481,7 +455,11 @@ class LangGraphTranslationPipeline:
 
         sense_summary = sense_payload.get("sense_summary", "")
         key_features = sense_payload.get("key_features") or []
-        key_features_str = "\n- ".join(str(item) for item in key_features) if key_features else "(none)"
+        key_features_str = (
+            "\n- ".join(str(item) for item in key_features)
+            if key_features
+            else "(none)"
+        )
 
         prompt = textwrap.dedent(
             f"""
@@ -514,11 +492,11 @@ class LangGraphTranslationPipeline:
         sense_payload: Dict[str, Any],
     ) -> str:
         """Generate prompt for initial lemma translation stage (improved: 1:1 alignment + null placeholders).
-        
+
         Args:
             synset: Source synset data.
             sense_payload: Output from sense analysis stage.
-            
+
         Returns:
             Formatted prompt for LLM.
         """
@@ -557,12 +535,12 @@ class LangGraphTranslationPipeline:
         definition_payload: Dict[str, Any],
     ) -> str:
         """Generate prompt for synonym expansion stage (improved: requires rationale for each new synonym).
-        
+
         Args:
             initial_payload: Output from initial translation stage.
             sense_payload: Output from sense analysis stage.
             definition_payload: Output from definition translation stage.
-            
+
         Returns:
             Formatted prompt for LLM.
         """
@@ -570,8 +548,12 @@ class LangGraphTranslationPipeline:
         initial_translations = initial_payload.get("initial_translations", [])
         # Filter out null values from initial translations
         initial_translations = [t for t in initial_translations if t is not None]
-        initial_str = ", ".join(str(t) for t in initial_translations) if initial_translations else "(none)"
-        
+        initial_str = (
+            ", ".join(str(t) for t in initial_translations)
+            if initial_translations
+            else "(none)"
+        )
+
         sense_summary = sense_payload.get("sense_summary", "")
         definition_translation = definition_payload.get("definition_translation", "")
 
@@ -605,19 +587,23 @@ class LangGraphTranslationPipeline:
         definition_payload: Dict[str, Any],
     ) -> str:
         """Generate prompt for synonym filtering/validation stage (improved: structured rejections + confidence level).
-        
+
         Args:
             expansion_payload: Output from expansion stage.
             sense_payload: Output from sense analysis stage.
             definition_payload: Output from definition translation stage.
-            
+
         Returns:
             Formatted prompt for LLM.
         """
         target_name = LanguageUtils.get_language_name(self.target_lang)
         expanded_synonyms = expansion_payload.get("expanded_synonyms", [])
-        expanded_str = ", ".join(str(t) for t in expanded_synonyms) if expanded_synonyms else "(none)"
-        
+        expanded_str = (
+            ", ".join(str(t) for t in expanded_synonyms)
+            if expanded_synonyms
+            else "(none)"
+        )
+
         sense_summary = sense_payload.get("sense_summary", "")
         definition_translation = definition_payload.get("definition_translation", "")
 
@@ -649,51 +635,82 @@ class LangGraphTranslationPipeline:
     # END OF PROMPT GENERATION METHODS
     # ============================================================================
 
-    def _call_llm(self, prompt: str, stage: str, retries: int = 2) -> Dict[str, Any]:
+    def _call_llm(
+        self, prompt: str, stage: str, retries: Optional[int] = None
+    ) -> Dict[str, Any]:
         """Invoke LLM with automatic JSON validation + retry on malformed output.
-        
+
         Args:
             prompt: User message to send to LLM.
             stage: Current pipeline stage (for logging).
             retries: Number of retry attempts on validation failure.
-            
+
         Returns:
             Dict containing prompt, response, parsed payload, and metadata.
         """
+        max_retries = self.max_retries if retries is None else max(0, int(retries))
         system_content = ""
         raw = ""
-        for attempt in range(retries + 1):
-            system_content = self.system_prompt + f"\nCurrent stage: {stage}. Return valid JSON as instructed."
+        for attempt in range(max_retries + 1):
+            system_content = (
+                self.system_prompt
+                + f"\nCurrent stage: {stage}. Return valid JSON as instructed."
+            )
             messages = [
                 self._SystemMessage(content=system_content),
                 self._HumanMessage(content=prompt),
             ]
+            log_event(
+                self.logger,
+                event="llm_call_attempt",
+                request_id=self.request_id,
+                stage=stage,
+                attempt=attempt + 1,
+                max_attempts=max_retries + 1,
+                timeout_seconds=self.timeout,
+            )
 
             try:
                 response = self.llm.invoke(messages)
                 content: Any = getattr(response, "content", response)
             except Exception as exc:
                 raw = str(exc)
-                if attempt < retries:
-                    print(
-                        f"[Retry {attempt + 1}/{retries}] LLM invoke failed for stage '{stage}': {exc}"
+                if attempt < max_retries:
+                    log_event(
+                        self.logger,
+                        event="llm_call_retry",
+                        request_id=self.request_id,
+                        stage=stage,
+                        level="warning",
+                        reason="invoke_exception",
+                        error=str(exc),
                     )
+                    time.sleep(self.retry_delay_seconds * (attempt + 1))
                     continue
-                print(
-                    f"[ERROR] LLM invoke failed for stage '{stage}' after retries: {exc}"
+                log_event(
+                    self.logger,
+                    event="llm_call_failed",
+                    request_id=self.request_id,
+                    stage=stage,
+                    level="error",
+                    error=str(exc),
                 )
                 break
 
             if isinstance(content, list):
                 combined = "".join(
-                    fragment.get("text", "") if isinstance(fragment, dict) else str(fragment)
+                    (
+                        fragment.get("text", "")
+                        if isinstance(fragment, dict)
+                        else str(fragment)
+                    )
                     for fragment in content
                 )
                 content = combined
 
             raw = str(content).strip()
             payload = self._decode_llm_payload(raw)
-            
+
             # Validate payload against schema for this stage
             payload = self._validate_payload_for_stage(stage, payload)
 
@@ -701,6 +718,7 @@ class LangGraphTranslationPipeline:
             if payload and any(payload.values()):
                 call_log = {
                     "stage": stage,
+                    "request_id": self.request_id,
                     "prompt": prompt,
                     "system_prompt": system_content,
                     "raw_response": raw,
@@ -710,20 +728,43 @@ class LangGraphTranslationPipeline:
                         {"role": "user", "content": prompt},
                     ],
                 }
+                log_event(
+                    self.logger,
+                    event="llm_call_succeeded",
+                    request_id=self.request_id,
+                    stage=stage,
+                    attempt=attempt + 1,
+                )
                 return call_log
-            
+
             # Log retry attempt
-            if attempt < retries:
-                print(f"[Retry {attempt + 1}/{retries}] Invalid or empty JSON for stage '{stage}'")
-        
+            if attempt < max_retries:
+                log_event(
+                    self.logger,
+                    event="llm_call_retry",
+                    request_id=self.request_id,
+                    stage=stage,
+                    level="warning",
+                    reason="invalid_or_empty_payload",
+                )
+                time.sleep(self.retry_delay_seconds * (attempt + 1))
+
         # Fallback return after max retries
-        print(f"[ERROR] Max retries exceeded for stage '{stage}', returning error payload")
+        log_event(
+            self.logger,
+            event="llm_call_max_retries_exceeded",
+            request_id=self.request_id,
+            stage=stage,
+            level="error",
+            max_attempts=max_retries + 1,
+        )
         fallback_payload = self._validate_payload_for_stage(stage, {})
         if not fallback_payload:
             fallback_payload = {"error": "max retries exceeded"}
 
         return {
             "stage": stage,
+            "request_id": self.request_id,
             "prompt": prompt,
             "system_prompt": system_content,
             "raw_response": raw,
@@ -737,10 +778,10 @@ class LangGraphTranslationPipeline:
     @staticmethod
     def _summarise_call(call: Dict[str, Any]) -> Dict[str, Any]:
         """Create a concise summary of an LLM call for logging.
-        
+
         Args:
             call: Full LLM call record with prompt, response, etc.
-            
+
         Returns:
             Summarised version with truncated response.
         """
@@ -749,13 +790,14 @@ class LangGraphTranslationPipeline:
 
         raw = call.get("raw_response", "")
         raw_preview = (
-            raw[:LangGraphTranslationPipeline._PREVIEW_LIMIT] + "… [truncated]" 
-            if raw and len(raw) > LangGraphTranslationPipeline._PREVIEW_LIMIT 
+            raw[: LangGraphTranslationPipeline._PREVIEW_LIMIT] + "… [truncated]"
+            if raw and len(raw) > LangGraphTranslationPipeline._PREVIEW_LIMIT
             else raw
         )
 
         return {
             "stage": call.get("stage"),
+            "request_id": call.get("request_id"),
             "prompt": call.get("prompt"),
             "system_prompt": call.get("system_prompt"),
             "raw_response_preview": raw_preview,
@@ -767,22 +809,15 @@ class LangGraphTranslationPipeline:
 
     def _validate_payload_for_stage(self, stage: str, payload: dict) -> dict:
         """Auto-choose schema based on stage name and validate payload.
-        
+
         Args:
             stage: Current pipeline stage name.
             payload: Raw dictionary from LLM output.
-            
+
         Returns:
             Validated and potentially repaired payload dictionary.
         """
-        schema_map = {
-            "sense_analysis": SenseAnalysisSchema,
-            "definition_translation": DefinitionTranslationSchema,
-            "initial_translation": LemmaTranslationSchema,
-            "synonym_expansion": ExpansionSchema,
-            "synonym_filtering": FilteringSchema,
-        }
-        schema_cls = schema_map.get(stage)
+        schema_cls = BASE_STAGE_SCHEMA_MAP.get(stage)
         if schema_cls:
             return validate_stage_payload(payload, schema_cls, stage)
         return payload
@@ -852,52 +887,54 @@ class LangGraphTranslationPipeline:
     @staticmethod
     def _get_wordnet_domain_info(english_id: str) -> Dict[str, Any]:
         """Fetch domain information from NLTK WordNet using english_id.
-        
+
         Returns both lexname (broad category) and topic_domains (semantic field markers).
-        
+
         Args:
             english_id: English WordNet synset ID (e.g., "ENG30-03574555-n")
-            
+
         Returns:
             Dictionary with 'lexname' and 'topic_domains' keys, or empty dict if not found.
         """
         if not english_id:
             return {}
-        
+
         try:
             from nltk.corpus import wordnet as wn
         except ImportError:
             # NLTK not available, skip domain lookup
             return {}
-        
+
         try:
             # Parse the english_id format (e.g., "ENG30-03574555-n")
             # Extract offset and POS
-            parts = english_id.split('-')
+            parts = english_id.split("-")
             if len(parts) < 3:
                 return {}
-            
+
             offset_str = parts[1]
             pos_char = LanguageUtils.normalize_pos_for_english(parts[2])
-            
+
             # Convert offset to integer
             offset = int(offset_str)
-            
+
             # Get the synset from WordNet
             synset = wn.synset_from_pos_and_offset(pos_char, offset)
-            
+
             # Get lexname (broad category like "noun.artifact", "verb.motion")
             lexname = synset.lexname()
-            
+
             # Get topic domains (semantic field markers like "biology.n.01", "music.n.01")
             topic_domains = synset.topic_domains()
-            topic_domain_names = [td.name() for td in topic_domains] if topic_domains else []
-            
+            topic_domain_names = (
+                [td.name() for td in topic_domains] if topic_domains else []
+            )
+
             return {
                 "lexname": lexname,
                 "topic_domains": topic_domain_names,
             }
-            
+
         except (ValueError, LookupError, AttributeError):
             # Could not parse or find synset
             return {}
@@ -906,7 +943,9 @@ class LangGraphTranslationPipeline:
     def _coerce_to_str_list(value: Any) -> List[str]:
         """Normalise unknown payload values into a cleaned list of strings."""
         if isinstance(value, (list, tuple)):
-            return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+            return [
+                item.strip() for item in value if isinstance(item, str) and item.strip()
+            ]
         if isinstance(value, str):
             text = value.strip()
             return [text] if text else []
@@ -914,17 +953,17 @@ class LangGraphTranslationPipeline:
 
     def _assemble_result(self, state: TranslationGraphState) -> TranslationGraphState:
         """LangGraph node: Combine all stage outputs into final result.
-        
+
         Args:
             state: Complete graph state with all translation stages.
-            
+
         Returns:
             Updated state with assembled TranslationResult.
         """
         synset = state["synset"]
         sense_call = state.get("sense_analysis", {}) or {}
         definition_call = state.get("definition_translation", {}) or {}
-        
+
         # Get results from the new multi-step synonym pipeline
         initial_call = state.get("initial_translation_call", {}) or {}
         expansion_call = state.get("expansion_call", {}) or {}
@@ -944,7 +983,7 @@ class LangGraphTranslationPipeline:
         # This is the high-quality synset produced by the generate-and-filter pipeline
         filtered_synonyms = filtering_payload.get("filtered_synonyms", [])
         translated_synonyms = self._coerce_to_str_list(filtered_synonyms)
-        
+
         # Remove any empty strings and deduplicate while preserving order
         seen = set()
         deduped_synonyms: List[str] = []
@@ -955,7 +994,7 @@ class LangGraphTranslationPipeline:
         translated_synonyms = deduped_synonyms
 
         # The "translation" field holds a representative literal for convenience
-        # (e.g., for logging or display). This is NOT a formal "headword" - 
+        # (e.g., for logging or display). This is NOT a formal "headword" -
         # the final output is a synset (set of synonymous literals).
         # We simply use the first item from the filtered list if available.
         translation = translated_synonyms[0] if translated_synonyms else ""
@@ -978,7 +1017,9 @@ class LangGraphTranslationPipeline:
         notes = str(notes).strip() if notes else None
 
         # Fetch domain information from English WordNet
-        english_id = synset.get("id") or synset.get("english_id") or synset.get("ili_id") or ""
+        english_id = (
+            synset.get("id") or synset.get("english_id") or synset.get("ili_id") or ""
+        )
         domain_info = self._get_wordnet_domain_info(english_id)
         lexname = domain_info.get("lexname")
         topic_domains = domain_info.get("topic_domains", [])
@@ -988,16 +1029,14 @@ class LangGraphTranslationPipeline:
         summary_lines.append(
             f"Representative literal ({self.target_lang}): {translation or '—'}"
         )
-        summary_lines.append(
-            f"Definition translation: {definition_translation or '—'}"
-        )
+        summary_lines.append(f"Definition translation: {definition_translation or '—'}")
         if lexname:
             summary_lines.append(f"Lexname: {lexname}")
         if topic_domains:
             summary_lines.append(f"Topic domains: {', '.join(topic_domains)}")
         if translated_synonyms:
             summary_lines.append(f"Synset literals ({len(translated_synonyms)} total):")
-            for syn in translated_synonyms[:self._MAX_SYNONYMS_DISPLAY]:
+            for syn in translated_synonyms[: self._MAX_SYNONYMS_DISPLAY]:
                 summary_lines.append(f"  • {syn}")
             if len(translated_synonyms) > self._MAX_SYNONYMS_DISPLAY:
                 summary_lines.append(
@@ -1007,16 +1046,14 @@ class LangGraphTranslationPipeline:
             summary_lines.append("Synset literals: (none returned)")
 
         if examples:
-            summary_lines.append(
-                f"Example sentences: {len(examples)} (showing first)"
-            )
+            summary_lines.append(f"Example sentences: {len(examples)} (showing first)")
             summary_lines.append(f"  “{examples[0]}”")
         else:
             summary_lines.append("Example sentences: none")
 
         if notes:
             summary_lines.append(f"Notes: {notes}")
-        
+
         # Add pipeline stage info
         summary_lines.append(f"\nPipeline stages completed:")
         summary_lines.append(
@@ -1027,7 +1064,9 @@ class LangGraphTranslationPipeline:
             "  2. Expanded candidates: "
             f"{len(self._coerce_to_str_list(expansion_payload.get('expanded_synonyms')))} synonyms"
         )
-        summary_lines.append(f"  3. Filtered results: {len(translated_synonyms)} final literals")
+        summary_lines.append(
+            f"  3. Filtered results: {len(translated_synonyms)} final literals"
+        )
 
         curator_summary = "\n".join(summary_lines)
 
@@ -1054,10 +1093,10 @@ class LangGraphTranslationPipeline:
         }
 
         raw_response = (
-            filtering_call.get("raw_response") 
-            or expansion_call.get("raw_response") 
+            filtering_call.get("raw_response")
+            or expansion_call.get("raw_response")
             or initial_call.get("raw_response")
-            or definition_call.get("raw_response") 
+            or definition_call.get("raw_response")
             or sense_call.get("raw_response", "")
         )
 

--- a/src/wordnet_autotranslate/pipelines/stages/__init__.py
+++ b/src/wordnet_autotranslate/pipelines/stages/__init__.py
@@ -1,0 +1,5 @@
+"""Stage-focused building blocks for pipeline execution."""
+
+from .schema_validation import BASE_STAGE_SCHEMA_MAP, validate_stage_payload
+
+__all__ = ["BASE_STAGE_SCHEMA_MAP", "validate_stage_payload"]

--- a/src/wordnet_autotranslate/pipelines/stages/schema_validation.py
+++ b/src/wordnet_autotranslate/pipelines/stages/schema_validation.py
@@ -1,0 +1,68 @@
+"""Centralized request/response schema validation for translation stages."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Type
+
+from pydantic import BaseModel, Field, ValidationError
+from pydantic_core import PydanticUndefined
+
+
+class SenseAnalysisSchema(BaseModel):
+    sense_summary: str = Field(..., min_length=3)
+    contrastive_note: Optional[str] = None
+    key_features: List[str] = Field(default_factory=list)
+    domain_tags: Optional[List[str]] = Field(default_factory=list)
+    confidence: str
+
+
+class DefinitionTranslationSchema(BaseModel):
+    definition_translation: str
+    notes: Optional[str] = None
+    examples: Optional[List[str]] = Field(default_factory=list)
+
+
+class LemmaTranslationSchema(BaseModel):
+    initial_translations: List[Optional[str]]
+    alignment: Dict[str, Optional[str]]
+
+
+class ExpansionSchema(BaseModel):
+    expanded_synonyms: List[str]
+    rationale: Optional[Dict[str, str]] = Field(default_factory=dict)
+
+
+class FilteringSchema(BaseModel):
+    filtered_synonyms: List[str]
+    removed: Optional[List[Dict[str, str]]] = Field(default_factory=list)
+    confidence: str
+
+
+BASE_STAGE_SCHEMA_MAP: Dict[str, Type[BaseModel]] = {
+    "sense_analysis": SenseAnalysisSchema,
+    "definition_translation": DefinitionTranslationSchema,
+    "initial_translation": LemmaTranslationSchema,
+    "synonym_expansion": ExpansionSchema,
+    "synonym_filtering": FilteringSchema,
+}
+
+
+def validate_stage_payload(
+    payload: dict, schema_cls: type[BaseModel], stage_name: str
+) -> dict:
+    """Validate LLM JSON payload against the expected schema."""
+    try:
+        model = schema_cls(**payload)
+        return model.model_dump()
+    except ValidationError:
+        fallback = {}
+        for field_name, field_info in schema_cls.model_fields.items():
+            if field_info.is_required():
+                fallback[field_name] = ""
+            elif field_info.default is not PydanticUndefined:
+                fallback[field_name] = field_info.default
+            elif field_info.default_factory is not None:
+                fallback[field_name] = field_info.default_factory()
+            else:
+                fallback[field_name] = None
+        return {**fallback, **payload, "_validation_error_stage": stage_name}

--- a/src/wordnet_autotranslate/utils/observability.py
+++ b/src/wordnet_autotranslate/utils/observability.py
@@ -1,0 +1,45 @@
+"""Structured observability helpers for translation workflows."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any, Dict, Optional
+
+
+def ensure_request_id(request_id: Optional[str] = None) -> str:
+    """Return a stable correlation id (generate one when omitted)."""
+    if request_id and str(request_id).strip():
+        return str(request_id).strip()
+    return str(uuid.uuid4())
+
+
+def get_structured_logger(name: str = "wordnet_autotranslate") -> logging.Logger:
+    """Create or return a logger configured for line-delimited JSON logs."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger
+
+
+def log_event(
+    logger: logging.Logger,
+    *,
+    event: str,
+    request_id: str,
+    stage: Optional[str] = None,
+    level: str = "info",
+    **fields: Any,
+) -> None:
+    """Emit a structured JSON log line with correlation metadata."""
+    payload: Dict[str, Any] = {"event": event, "request_id": request_id}
+    if stage:
+        payload["stage"] = stage
+    payload.update(fields)
+    line = json.dumps(payload, ensure_ascii=False, default=str)
+    log_fn = getattr(logger, level, logger.info)
+    log_fn(line)

--- a/src/wordnet_autotranslate/workflows/selector_validation.py
+++ b/src/wordnet_autotranslate/workflows/selector_validation.py
@@ -1,0 +1,49 @@
+"""Shared selector validation helpers for CLI and workflow entrypoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class SelectorValidationResult:
+    """Simple result object for selector-family validation."""
+
+    selector_count: int
+    has_english_id: bool
+    has_synset_name: bool
+    has_lemma_pos: bool
+
+
+def validate_selector_families(
+    *,
+    english_id: Optional[str] = None,
+    synset_name: Optional[str] = None,
+    lemma: Optional[str] = None,
+    pos: Optional[str] = None,
+) -> SelectorValidationResult:
+    """Validate that exactly one selector family is provided.
+
+    Selector families:
+    - english_id
+    - synset_name
+    - lemma+pos
+    """
+
+    has_english_id = bool(english_id)
+    has_synset_name = bool(synset_name)
+    has_lemma_pos = bool(lemma and pos)
+    selector_count = sum([has_english_id, has_synset_name, has_lemma_pos])
+
+    if selector_count != 1:
+        raise ValueError(
+            "Provide exactly one selector: english_id OR synset_name OR lemma+pos."
+        )
+
+    return SelectorValidationResult(
+        selector_count=selector_count,
+        has_english_id=has_english_id,
+        has_synset_name=has_synset_name,
+        has_lemma_pos=has_lemma_pos,
+    )

--- a/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
+++ b/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
@@ -15,9 +15,12 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..pipelines.translation_pipeline import TranslationPipeline
-from ..pipelines.conceptual_langgraph_pipeline import ConceptualLangGraphTranslationPipeline
+from ..pipelines.conceptual_langgraph_pipeline import (
+    ConceptualLangGraphTranslationPipeline,
+)
 from ..pipelines.langgraph_translation_pipeline import LangGraphTranslationPipeline
 from ..utils.language_utils import LanguageUtils
+from .selector_validation import validate_selector_families
 
 
 @dataclass(frozen=True)
@@ -25,9 +28,11 @@ class WorkflowConfig:
     source_lang: str = "en"
     target_lang: str = "sr"
     model: str = "gpt-oss:120b"
-    timeout: int = 600
+    timeout: int = 1800
     base_url: str = "http://localhost:11434"
     temperature: float = 0.2
+    max_retries: int = 2
+    retry_delay_seconds: float = 1.0
     strict: bool = False
 
 
@@ -40,7 +45,11 @@ def parse_eng30_id(english_id: str) -> Tuple[int, str]:
         )
 
     offset_token = parts[1]
-    if len(offset_token) != 8 or not offset_token.isascii() or not offset_token.isdigit():
+    if (
+        len(offset_token) != 8
+        or not offset_token.isascii()
+        or not offset_token.isdigit()
+    ):
         raise ValueError(
             f"parse_eng30_id: invalid offset in selector {english_id!r}; offset must be exactly 8 digits."
         )
@@ -115,6 +124,13 @@ def resolve_wordnet_synset(
     """Resolve a synset from one of the supported selectors and return payload."""
     from nltk.corpus import wordnet as wn
 
+    validate_selector_families(
+        english_id=english_id,
+        synset_name=synset_name,
+        lemma=lemma,
+        pos=pos,
+    )
+
     if english_id:
         offset, mapped_pos = parse_eng30_id(english_id)
         synset = wn.synset_from_pos_and_offset(mapped_pos, offset)
@@ -133,7 +149,7 @@ def resolve_wordnet_synset(
         return synset_to_payload(candidates[idx])
 
     raise ValueError(
-        "Provide one selector: english_id OR synset_name OR lemma+pos."
+        "Provide exactly one selector: english_id OR synset_name OR lemma+pos."
     )
 
 
@@ -171,6 +187,9 @@ def run_translation_workflow(
             timeout=config.timeout,
             base_url=config.base_url,
             temperature=config.temperature,
+            max_retries=config.max_retries,
+            retry_delay_seconds=config.retry_delay_seconds,
+            request_id=synset_payload.get("id") or synset_payload.get("english_id"),
         )
         _run_with_capture("langgraph", lambda: lg.translate_synset(synset_payload))
 
@@ -182,6 +201,9 @@ def run_translation_workflow(
             timeout=config.timeout,
             base_url=config.base_url,
             temperature=config.temperature,
+            max_retries=config.max_retries,
+            retry_delay_seconds=config.retry_delay_seconds,
+            request_id=synset_payload.get("id") or synset_payload.get("english_id"),
         )
         _run_with_capture("conceptual", lambda: cg.translate_synset(synset_payload))
 
@@ -200,7 +222,9 @@ def run_translation_workflow(
             }
 
     if not results["pipelines"]:
-        raise ValueError("Unsupported pipeline. Use: langgraph | conceptual | all | dspy")
+        raise ValueError(
+            "Unsupported pipeline. Use: langgraph | conceptual | all | dspy"
+        )
 
     return results
 

--- a/tests/test_langgraph_pipeline.py
+++ b/tests/test_langgraph_pipeline.py
@@ -409,6 +409,7 @@ def test_call_llm_fallback_payload_shape_after_repeated_invoke_exceptions():
     assert isinstance(payload["key_features"], list)
     assert isinstance(payload["domain_tags"], list)
     assert call["raw_response"] == "transport down"
+    assert "request_id" in call
 
 
 @pytest.mark.parametrize(
@@ -459,6 +460,16 @@ def test_call_llm_fallback_payload_shape_matrix_after_repeated_invoke_exceptions
     payload = call["payload"]
     assert set(payload.keys()) == expected_keys
     assert call["raw_response"] == f"{stage} transport down"
+
+
+def test_pipeline_bounds_timeout_to_maximum():
+    pipeline = LangGraphTranslationPipeline(
+        source_lang="en",
+        target_lang="sr",
+        llm=_DummyLLM(),
+        timeout=99999,
+    )
+    assert pipeline.timeout == LangGraphTranslationPipeline.MAX_TIMEOUT
 
 
 def test_translation_result_to_dict():

--- a/tests/test_selector_validation.py
+++ b/tests/test_selector_validation.py
@@ -1,0 +1,19 @@
+import pytest
+
+from wordnet_autotranslate.workflows.selector_validation import (
+    validate_selector_families,
+)
+
+
+def test_validate_selector_families_accepts_english_id():
+    result = validate_selector_families(english_id="ENG30-00001740-n")
+    assert result.selector_count == 1
+    assert result.has_english_id
+
+
+def test_validate_selector_families_rejects_conflicts():
+    with pytest.raises(ValueError, match="exactly one selector"):
+        validate_selector_families(
+            english_id="ENG30-00001740-n",
+            synset_name="entity.n.01",
+        )

--- a/tests/test_synset_translation_workflow.py
+++ b/tests/test_synset_translation_workflow.py
@@ -6,6 +6,7 @@ from wordnet_autotranslate.workflows import synset_translation_workflow as workf
 from wordnet_autotranslate.workflows.synset_translation_workflow import (
     WorkflowConfig,
     parse_eng30_id,
+    resolve_wordnet_synset,
     run_translation_workflow,
     synset_to_payload,
     _resolve_sense_index,
@@ -153,7 +154,9 @@ def test_parse_eng30_id_generated_fuzz_cases():
         delim = rng.choice(delimiters)
         offset_len = rng.choice([1, 2, 3, 4, 5, 6, 7, 9, 10])
         offset = "".join(rng.choice(string.digits) for _ in range(offset_len))
-        pos = rng.choice([ch for ch in (string.ascii_letters + "!?") if ch.lower() not in "nvasrb"])
+        pos = rng.choice(
+            [ch for ch in (string.ascii_letters + "!?") if ch.lower() not in "nvasrb"]
+        )
         parts = ["ENG30", offset, pos]
         if rng.random() < 0.5:
             parts.append("extra")
@@ -247,9 +250,7 @@ def test_run_translation_workflow_capture_errors_when_non_strict(monkeypatch):
         def translate_synset(self, synset):
             raise RuntimeError("llm unavailable")
 
-    monkeypatch.setattr(
-        workflow_mod, "LangGraphTranslationPipeline", _FailingLangGraph
-    )
+    monkeypatch.setattr(workflow_mod, "LangGraphTranslationPipeline", _FailingLangGraph)
     result = run_translation_workflow(
         {"id": "ENG30-00001740-n"},
         pipeline="langgraph",
@@ -266,12 +267,23 @@ def test_run_translation_workflow_raises_when_strict(monkeypatch):
         def translate_synset(self, synset):
             raise RuntimeError("llm unavailable")
 
-    monkeypatch.setattr(
-        workflow_mod, "LangGraphTranslationPipeline", _FailingLangGraph
-    )
+    monkeypatch.setattr(workflow_mod, "LangGraphTranslationPipeline", _FailingLangGraph)
     with pytest.raises(RuntimeError, match="llm unavailable"):
         run_translation_workflow(
             {"id": "ENG30-00001740-n"},
             pipeline="langgraph",
             config=WorkflowConfig(strict=True),
+        )
+
+
+def test_resolve_wordnet_synset_requires_exactly_one_selector_missing():
+    with pytest.raises(ValueError, match="exactly one selector"):
+        resolve_wordnet_synset()
+
+
+def test_resolve_wordnet_synset_requires_exactly_one_selector_conflict():
+    with pytest.raises(ValueError, match="exactly one selector"):
+        resolve_wordnet_synset(
+            english_id="ENG30-00001740-n",
+            synset_name="entity.n.01",
         )

--- a/tests/test_translate_synset_cli.py
+++ b/tests/test_translate_synset_cli.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 import pytest
 
-SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "translate_synset_workflow.py"
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "translate_synset_workflow.py"
+)
 
 _spec = importlib.util.spec_from_file_location("translate_synset_workflow", SCRIPT_PATH)
 cli = importlib.util.module_from_spec(_spec)
@@ -26,3 +28,13 @@ def test_cli_keyboard_interrupt_returns_130(monkeypatch):
 
     monkeypatch.setattr(cli, "resolve_wordnet_synset", _raise_interrupt)
     assert cli.main() == 130
+
+
+def test_cli_rejects_multiple_selector_families(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["prog", "--english-id", "ENG30-00001740-n", "--synset-name", "entity.n.01"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2


### PR DESCRIPTION
### Motivation
- Centralize and harden stage-level JSON schema validation for LLM responses to improve robustness of the multi-stage translation pipelines.
- Add retry/backoff, timeout bounds, and structured observability to make LLM calls more reliable and auditable.
- Prevent ambiguous CLI selector usage by enforcing exactly-one selector family for synset resolution.
- Introduce CI and security workflows to run formatting, tests, dependency audits, and secret scanning on push/pull requests.

### Description
- Introduce a new `pipelines/stages/schema_validation.py` and `__init__.py` to centralize Pydantic schemas and `validate_stage_payload`, and update pipelines to use this shared validator.
- Extend `LangGraphTranslationPipeline` with bounded timeouts, configurable `max_retries`/`retry_delay_seconds`, `request_id` correlation, structured logging via new `utils/observability.py`, improved `_call_llm` retry/backoff logic, and schema-driven payload fallbacks; also adjust prompt formatting and minor prompt text refactors.
- Add `ConceptualLangGraphTranslationPipeline` changes to use the centralized validation and normalize prompt string construction.
- Add `workflows/selector_validation.py` and wire validation into `scripts/translate_synset_workflow.py` and `workflows/synset_translation_workflow.py` to require exactly one selector family; update CLI to accept `--max-retries`, `--retry-delay-seconds`, and increase default `--timeout`.
- Add supporting modules and tests: `utils/observability.py`, `pipelines/stages` package, and new/updated tests (`tests/test_selector_validation.py`, updates to `tests/test_langgraph_pipeline.py`, `tests/test_synset_translation_workflow.py`, and `tests/test_translate_synset_cli.py`).
- Add CI configuration files `.github/workflows/ci.yml` and `.github/workflows/security.yml`, and create `SECURITY.md`; update `README.md` with CLI usage notes and add `pydantic` to `pyproject.toml` dependencies.

### Testing
- Ran the unit test suite with `pytest -q`, including new tests `tests/test_selector_validation.py` and updated pipeline/CLI tests, and observed all tests pass.
- Verified CLI behavior changes via the added CLI unit tests that exercise selector validation and keyboard-interrupt handling using the test harness.
- Performed a local format check with `python -m black --check` to ensure formatting consistency used by CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd146f597083298af4461676641445)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI adds configurable timeout and retry controls; selector arguments now enforce exactly-one selection and clearer errors.
  * Translation pipelines now include bounded timeouts, retry behavior, and request-level identifiers for improved logging.

* **Documentation**
  * Added security policy and updated CLI usage/flags.

* **Chores**
  * Added CI and secret-scan workflows plus a secrets/scan configuration file; pinned a runtime dependency.

* **Tests**
  * New and updated unit tests covering selector validation, timeouts, and request-id behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->