### PR TITLE
fix(baseline): wire LLM config, fix invoke format, dynamic lang names, dspy compat key

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jupyter notebook
 
 ## Usage
 
-## Dissertation workflow framing
+### Dissertation workflow framing
 
 The repository currently exposes three synset-translation workflows:
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # WordNet Auto-Translation
 
-A core tool for automatic expansion of WordNet in less-resourced languages, using precision words and examples from target languages. This project leverages DSPy Pipelines & Prompt Optimization to load synsets in both English and target languages, utilizing a trained translation pipeline.
+A tool for automatic expansion of WordNet in less-resourced languages, with workflows for Serbian synset drafting and side-by-side pipeline comparison.
 
 ## Overview
 
 This project aims to bridge the gap in WordNet coverage for less-resourced languages by:
 - Loading existing synsets from both English and target languages
-- Using DSPy pipelines for optimized prompt-based translation
+- Running three dissertation-aligned synset translation workflows
 - Leveraging precision words and contextual examples for accurate translations
 - Providing tools for automatic WordNet expansion
 
 ## Features
 
-- **DSPy Integration**: Uses DSPy pipelines and prompt optimization for robust translation
+- **Three-workflow framing**: baseline, multi-phase (LangGraph), and concept-oriented pipelines
 - **Multi-language Support**: Handles English as source and various target languages
 - **Example-based Learning**: Utilizes examples from target languages for better context
 - **Serbian WordNet GUI**: Interactive browser for Serbian synsets with English pairing functionality
@@ -58,6 +58,16 @@ jupyter notebook
 
 ## Usage
 
+## Dissertation workflow framing
+
+The repository currently exposes three synset-translation workflows:
+
+1. **Baseline workflow** (`baseline`): direct translation using only English gloss + English literals.
+2. **Multi-phase workflow** (`langgraph`): analyze sense → translate gloss → translate literals → expand candidates → filter → assemble.
+3. **Concept-oriented workflow** (`conceptual`): concept package → expanded EN/SR definitions → candidate generation/selection → final gloss → validation.
+
+Use `scripts/translate_synset_workflow.py --pipeline all` for side-by-side comparison output.
+
 ### Serbian WordNet Synset Browser (GUI)
 
 Launch the interactive GUI for browsing and pairing Serbian synsets.
@@ -80,23 +90,28 @@ The GUI provides:
 
 See [GUI_README.md](GUI_README.md) for detailed usage instructions.
 
-### Basic Translation Pipeline
+### Baseline Translation Workflow (direct gloss + literals)
 
 ```python
-from wordnet_autotranslate import TranslationPipeline
+from wordnet_autotranslate import BaselineTranslationPipeline
 
-# Initialize pipeline for target language
-pipeline = TranslationPipeline(
-    source_lang='en',
-    target_lang='your_target_language'
+pipeline = BaselineTranslationPipeline(source_lang="en", target_lang="sr")
+
+result = pipeline.translate_synset(
+    {
+        "id": "ENG30-00001740-n",
+        "lemmas": ["entity"],
+        "definition": "that which is perceived or known to have its own distinct existence",
+        "pos": "n",
+    }
 )
 
-# Load synsets
-english_synsets = pipeline.load_english_synsets()
-target_synsets = pipeline.load_target_synsets()
-
-# Run translation
-translated_synsets = pipeline.translate(english_synsets)
+# Result keys include:
+# - translation
+# - definition_translation
+# - translated_synonyms
+# - payload
+# - curator_summary
 ```
 
 ### LangGraph + Ollama Translation Pipeline
@@ -235,7 +250,7 @@ Explore the interactive notebooks in the `notebooks/` directory for:
 ```
 wordnet_autotranslate/
 ├── src/                    # Core source code
-│   ├── pipelines/         # DSPy translation pipelines
+│   ├── pipelines/         # Translation workflow implementations
 │   ├── models/            # Language models and synset handlers
 │   │   ├── synset_handler.py      # English WordNet interface
 │   │   └── xml_synset_parser.py   # Serbian synset XML parser
@@ -289,7 +304,7 @@ This project supports expansion to any language. Current examples include:
 ## Requirements
 
 - Python 3.8+
-- DSPy framework
+- Optional LangGraph stack for multi-phase workflows
 - Jupyter (for interactive development)
 - NLTK (for WordNet access)
 - Transformers (for language models)
@@ -301,5 +316,5 @@ This project is licensed under CC0 1.0 Universal (CC0-1.0) - see the LICENSE fil
 ## Acknowledgments
 
 - WordNet project for the foundational lexical database
-- DSPy team for the optimization framework
+- LangGraph and Ollama communities for orchestration/runtime tooling
 - Contributors to less-resourced language resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 authors = [
     {name = "WordNet Auto-Translation Contributors"},
 ]
-description = "Automatic expansion of WordNet in less-resourced languages using DSPy"
+description = "Automatic expansion of WordNet in less-resourced languages with baseline and LangGraph workflows"
 readme = "README.md"
 license = {text = "CC0-1.0"}
 requires-python = ">=3.8"

--- a/scripts/translate_synset_workflow.py
+++ b/scripts/translate_synset_workflow.py
@@ -25,8 +25,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--pipeline",
         default="langgraph",
-        choices=["langgraph", "conceptual", "all", "dspy"],
-        help="Pipeline(s) to run",
+        choices=["baseline", "langgraph", "conceptual", "all", "dspy"],
+        help="Pipeline(s) to run (dspy is a legacy alias for baseline)",
     )
     parser.add_argument("--model", default="gpt-oss:120b", help="Ollama model name")
     parser.add_argument("--base-url", default="http://localhost:11434", help="Ollama base URL")

--- a/src/wordnet_autotranslate/__init__.py
+++ b/src/wordnet_autotranslate/__init__.py
@@ -2,13 +2,13 @@
 WordNet Auto-Translation Package
 
 A core tool for automatic expansion of WordNet in less-resourced languages.
-Uses DSPy pipelines and prompt optimization for translation tasks.
+Provides baseline, multi-phase, and concept-oriented translation workflows.
 """
 
 __version__ = "0.1.0"
 __author__ = "WordNet Auto-Translation Contributors"
 
-from .pipelines.translation_pipeline import TranslationPipeline
+from .pipelines.translation_pipeline import BaselineTranslationPipeline, TranslationPipeline
 from .pipelines.langgraph_translation_pipeline import LangGraphTranslationPipeline
 from .pipelines.conceptual_langgraph_pipeline import (
     ConceptualLangGraphTranslationPipeline,
@@ -24,6 +24,7 @@ from .workflows.synset_translation_workflow import (
 )
 
 __all__ = [
+    "BaselineTranslationPipeline",
     "TranslationPipeline",
     "LangGraphTranslationPipeline",
     "ConceptualLangGraphTranslationPipeline",

--- a/src/wordnet_autotranslate/pipelines/__init__.py
+++ b/src/wordnet_autotranslate/pipelines/__init__.py
@@ -1,11 +1,12 @@
 """Translation pipelines for WordNet auto-translation."""
 
-from .translation_pipeline import TranslationPipeline
+from .translation_pipeline import BaselineTranslationPipeline, TranslationPipeline
 from .langgraph_translation_pipeline import LangGraphTranslationPipeline
 from .conceptual_langgraph_pipeline import ConceptualLangGraphTranslationPipeline
 from .serbian_wordnet_pipeline import SerbianWordnetPipeline
 
 __all__ = [
+    "BaselineTranslationPipeline",
     "TranslationPipeline",
     "LangGraphTranslationPipeline",
     "ConceptualLangGraphTranslationPipeline",

--- a/src/wordnet_autotranslate/pipelines/conceptual_langgraph_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/conceptual_langgraph_pipeline.py
@@ -193,7 +193,7 @@ class ConceptualTranslationResult:
 
 
 class ConceptualLangGraphTranslationPipeline(LangGraphTranslationPipeline):
-    """Alternative LangGraph pipeline based on a concept package workflow."""
+    """Dissertation concept-oriented workflow using a concept-package graph."""
 
     def _build_graph(self) -> Any:
         """Build and compile the concept-oriented LangGraph state machine."""

--- a/src/wordnet_autotranslate/pipelines/langgraph_translation_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/langgraph_translation_pipeline.py
@@ -165,7 +165,7 @@ def validate_stage_payload(payload: dict, schema_cls: type[BaseModel], stage_nam
 
 
 class LangGraphTranslationPipeline:
-    """Alternative translation pipeline that uses LangGraph + Ollama."""
+    """Dissertation multi-phase workflow implemented with LangGraph + Ollama."""
 
     # Default configuration constants
     DEFAULT_SYSTEM_PROMPT: str = (

--- a/src/wordnet_autotranslate/pipelines/translation_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/translation_pipeline.py
@@ -29,7 +29,7 @@ class BaselineTranslationPipeline:
     """Simple direct-translation baseline for WordNet synsets."""
 
     DEFAULT_SYSTEM_PROMPT: str = (
-        "You are a bilingual lexicographer. Translate only the provided English "
+        "You are a bilingual lexicographer. Translate only the provided "
         "WordNet gloss and literals into the target language. Return JSON only."
     )
 
@@ -37,14 +37,26 @@ class BaselineTranslationPipeline:
         self,
         source_lang: str = "en",
         target_lang: str = "sr",
+        model: str = "gpt-oss:120b",
+        temperature: float = 0.2,
+        base_url: str = "http://localhost:11434",
+        timeout: int = 600,
         llm: Optional[Any] = None,
         system_prompt: Optional[str] = None,
     ) -> None:
         self.source_lang = source_lang
         self.target_lang = target_lang
-        self.llm = llm
+        self.model = model
+        self.temperature = temperature
+        self.base_url = base_url
+        self.timeout = timeout
         self.system_prompt = system_prompt or self.DEFAULT_SYSTEM_PROMPT
         self.examples_path = Path(__file__).parent.parent.parent.parent / "examples"
+
+        if llm is not None:
+            self.llm = llm
+        else:
+            self.llm = self._build_llm()
 
     def load_english_synsets(self) -> List[Dict[str, Any]]:
         """Load English synsets (placeholder for future dataset adapters)."""
@@ -129,6 +141,20 @@ class BaselineTranslationPipeline:
         for synset in synsets:
             yield self.translate_synset(synset)
 
+    def _build_llm(self) -> Optional[Any]:
+        """Build a ChatOllama LLM instance if langchain_ollama is available."""
+        try:
+            from langchain_ollama import ChatOllama  # type: ignore[import]
+
+            return ChatOllama(
+                model=self.model,
+                temperature=self.temperature,
+                timeout=self.timeout,
+                base_url=self.base_url,
+            )
+        except ImportError:
+            return None
+
     def _call_llm(self, *, lemmas: List[str], definition: str) -> Dict[str, Any]:
         """Call the configured LLM if present; otherwise use deterministic fallback."""
         prompt = self._render_prompt(lemmas=lemmas, definition=definition)
@@ -145,12 +171,11 @@ class BaselineTranslationPipeline:
                 "payload": fallback_payload,
             }
 
-        response = self.llm.invoke(
-            [
-                {"role": "system", "content": self.system_prompt},
-                {"role": "user", "content": prompt},
-            ]
+        combined_prompt = (
+            f"System instructions:\n{self.system_prompt}\n\n"
+            f"User request:\n{prompt}"
         )
+        response = self.llm.invoke(combined_prompt)
         content: Any = getattr(response, "content", response)
         raw_response = str(content).strip()
         payload = self._decode_llm_payload(raw_response)
@@ -162,13 +187,14 @@ class BaselineTranslationPipeline:
         }
 
     def _render_prompt(self, *, lemmas: List[str], definition: str) -> str:
+        source_name = LanguageUtils.get_language_name(self.source_lang)
         target_name = LanguageUtils.get_language_name(self.target_lang)
         return (
             "Baseline WordNet synset translation. Use only the provided gloss and literals.\n"
-            f"Source language: {self.source_lang}\n"
+            f"Source language: {self.source_lang} ({source_name})\n"
             f"Target language: {self.target_lang} ({target_name})\n"
-            f"English literals: {lemmas}\n"
-            f"English gloss: {definition or '(missing)'}\n\n"
+            f"{source_name} literals: {lemmas}\n"
+            f"{source_name} gloss: {definition or '(missing)'}\n\n"
             "Return JSON with keys:\n"
             "- definition_translation: translated gloss\n"
             "- translated_synonyms: list of translated literals\n"

--- a/src/wordnet_autotranslate/pipelines/translation_pipeline.py
+++ b/src/wordnet_autotranslate/pipelines/translation_pipeline.py
@@ -1,88 +1,213 @@
-"""
-Translation Pipeline using DSPy for WordNet auto-translation.
+"""Baseline synset-translation pipeline.
+
+This module implements the dissertation's baseline workflow:
+English gloss + English literals -> Serbian gloss + Serbian literals.
+
+`TranslationPipeline` is kept as a compatibility alias for older imports.
 """
 
+from __future__ import annotations
+
+import json
 from functools import lru_cache
-from typing import List, Dict, Tuple
 from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
-try:
-    import dspy
-    DSPY_AVAILABLE = True
-except ImportError:
-    DSPY_AVAILABLE = False
+from ..utils.language_utils import LanguageUtils
 
 
 @lru_cache(maxsize=128)
 def _load_text_file(file_path: str) -> Tuple[str, ...]:
-    """
-    Load and cache text file contents.
-    
-    Args:
-        file_path: Path to the text file
-        
-    Returns:
-        Tuple of non-empty, non-comment lines (immutable for caching)
-    """
-    with open(file_path, 'r', encoding='utf-8') as f:
+    """Load and cache text file contents."""
+    with open(file_path, "r", encoding="utf-8") as f:
         return tuple(
-            line.strip() for line in f 
-            if line.strip() and not line.startswith('#')
+            line.strip() for line in f if line.strip() and not line.startswith("#")
         )
 
 
-class TranslationPipeline:
-    """Main translation pipeline for WordNet synset translation."""
-    
-    def __init__(self, source_lang: str = 'en', target_lang: str = 'es'):
-        """
-        Initialize translation pipeline.
-        
-        Args:
-            source_lang: Source language code (default: 'en')
-            target_lang: Target language code (default: 'es')
-        """
+class BaselineTranslationPipeline:
+    """Simple direct-translation baseline for WordNet synsets."""
+
+    DEFAULT_SYSTEM_PROMPT: str = (
+        "You are a bilingual lexicographer. Translate only the provided English "
+        "WordNet gloss and literals into the target language. Return JSON only."
+    )
+
+    def __init__(
+        self,
+        source_lang: str = "en",
+        target_lang: str = "sr",
+        llm: Optional[Any] = None,
+        system_prompt: Optional[str] = None,
+    ) -> None:
         self.source_lang = source_lang
         self.target_lang = target_lang
+        self.llm = llm
+        self.system_prompt = system_prompt or self.DEFAULT_SYSTEM_PROMPT
         self.examples_path = Path(__file__).parent.parent.parent.parent / "examples"
-        
-    def load_english_synsets(self) -> List[Dict]:
-        """Load English WordNet synsets."""
-        # TODO: Implement WordNet loading
+
+    def load_english_synsets(self) -> List[Dict[str, Any]]:
+        """Load English synsets (placeholder for future dataset adapters)."""
         return []
-    
-    def load_target_synsets(self) -> List[Dict]:
-        """Load target language synsets if available."""
-        # TODO: Implement target language synset loading
+
+    def load_target_synsets(self) -> List[Dict[str, Any]]:
+        """Load target-language synsets (placeholder for future adapters)."""
         return []
-    
+
     def load_examples(self) -> Dict[str, List[str]]:
-        """Load examples for the target language with caching."""
+        """Load language examples with cached file reads."""
         examples = {"words": [], "sentences": []}
-        
+
         target_path = self.examples_path / self.target_lang
         if target_path.exists():
-            # Load words using cached helper
             words_file = target_path / "words.txt"
             if words_file.exists():
                 examples["words"] = list(_load_text_file(str(words_file)))
-            
-            # Load sentences using cached helper
+
             sentences_file = target_path / "sentences.txt"
             if sentences_file.exists():
                 examples["sentences"] = list(_load_text_file(str(sentences_file)))
-        
+
         return examples
-    
-    def translate(self, synsets: List[Dict]) -> List[Dict]:
-        """
-        Translate synsets using DSPy pipeline.
-        
-        Args:
-            synsets: List of synsets to translate
-            
-        Returns:
-            List of translated synsets
-        """
-        # TODO: Implement DSPy-based translation
+
+    def translate_synset(self, synset: Dict[str, Any]) -> Dict[str, Any]:
+        """Translate one synset using only gloss and literals."""
+        lemmas = self._coerce_to_str_list(synset.get("lemmas") or synset.get("literals"))
+        definition = str(synset.get("definition") or synset.get("gloss") or "").strip()
+
+        call_log = self._call_llm(lemmas=lemmas, definition=definition)
+        payload = call_log.get("payload", {})
+
+        definition_translation = str(payload.get("definition_translation") or "").strip()
+        translated_synonyms = self._coerce_to_str_list(
+            payload.get("translated_synonyms") or payload.get("selected_literals_sr")
+        )
+
+        if not translated_synonyms:
+            translated_synonyms = [item for item in lemmas if item]
+        translation = translated_synonyms[0] if translated_synonyms else ""
+
+        if not definition_translation:
+            definition_translation = definition
+
+        summary = (
+            f"Baseline workflow ({self.source_lang}->{self.target_lang}) produced "
+            f"{len(translated_synonyms)} literal(s) from gloss+literals only. "
+            f"Representative literal: '{translation or '(none)'}'."
+        )
+
+        return {
+            "translation": translation,
+            "definition_translation": definition_translation,
+            "translated_synonyms": translated_synonyms,
+            "target_lang": self.target_lang,
+            "source_lang": self.source_lang,
+            "source": {
+                "id": synset.get("id") or synset.get("english_id"),
+                "name": synset.get("name"),
+                "pos": synset.get("pos") or synset.get("part_of_speech"),
+                "lemmas": lemmas,
+                "definition": definition,
+            },
+            "payload": {
+                "baseline": payload,
+                "call": {
+                    "prompt": call_log.get("prompt", ""),
+                    "raw_response": call_log.get("raw_response", ""),
+                },
+            },
+            "source_selector": synset.get("id") or synset.get("english_id"),
+            "curator_summary": summary,
+        }
+
+    def translate(self, synsets: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Translate a sequence of synsets."""
+        return [self.translate_synset(synset) for synset in synsets]
+
+    def translate_stream(self, synsets: Iterable[Dict[str, Any]]) -> Iterable[Dict[str, Any]]:
+        """Yield baseline translations one by one."""
+        for synset in synsets:
+            yield self.translate_synset(synset)
+
+    def _call_llm(self, *, lemmas: List[str], definition: str) -> Dict[str, Any]:
+        """Call the configured LLM if present; otherwise use deterministic fallback."""
+        prompt = self._render_prompt(lemmas=lemmas, definition=definition)
+
+        if self.llm is None:
+            fallback_payload = {
+                "definition_translation": definition,
+                "translated_synonyms": lemmas,
+                "notes": "No LLM configured; returned deterministic baseline fallback.",
+            }
+            return {
+                "prompt": prompt,
+                "raw_response": json.dumps(fallback_payload, ensure_ascii=False),
+                "payload": fallback_payload,
+            }
+
+        response = self.llm.invoke(
+            [
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": prompt},
+            ]
+        )
+        content: Any = getattr(response, "content", response)
+        raw_response = str(content).strip()
+        payload = self._decode_llm_payload(raw_response)
+
+        return {
+            "prompt": prompt,
+            "raw_response": raw_response,
+            "payload": payload,
+        }
+
+    def _render_prompt(self, *, lemmas: List[str], definition: str) -> str:
+        target_name = LanguageUtils.get_language_name(self.target_lang)
+        return (
+            "Baseline WordNet synset translation. Use only the provided gloss and literals.\n"
+            f"Source language: {self.source_lang}\n"
+            f"Target language: {self.target_lang} ({target_name})\n"
+            f"English literals: {lemmas}\n"
+            f"English gloss: {definition or '(missing)'}\n\n"
+            "Return JSON with keys:\n"
+            "- definition_translation: translated gloss\n"
+            "- translated_synonyms: list of translated literals\n"
+            "- notes: optional short note\n"
+        )
+
+    @staticmethod
+    def _decode_llm_payload(raw: str) -> Dict[str, Any]:
+        if not raw:
+            return {"definition_translation": "", "translated_synonyms": []}
+        try:
+            decoded = json.loads(raw)
+            if isinstance(decoded, dict):
+                return decoded
+        except json.JSONDecodeError:
+            pass
+
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            snippet = raw[start : end + 1]
+            try:
+                decoded = json.loads(snippet)
+                if isinstance(decoded, dict):
+                    return decoded
+            except json.JSONDecodeError:
+                pass
+
+        return {"definition_translation": "", "translated_synonyms": []}
+
+    @staticmethod
+    def _coerce_to_str_list(value: Any) -> List[str]:
+        if isinstance(value, (list, tuple)):
+            return [str(item).strip() for item in value if str(item).strip()]
+        if isinstance(value, str):
+            text = value.strip()
+            return [text] if text else []
         return []
+
+
+class TranslationPipeline(BaselineTranslationPipeline):
+    """Compatibility alias for the baseline workflow implementation."""

--- a/src/wordnet_autotranslate/utils/language_utils.py
+++ b/src/wordnet_autotranslate/utils/language_utils.py
@@ -19,6 +19,7 @@ class LanguageUtils:
         'pt': 'Portuguese',
         'it': 'Italian',
         'ru': 'Russian',
+        'sr': 'Serbian',
         'zh': 'Chinese',
         'ja': 'Japanese',
         'ko': 'Korean'

--- a/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
+++ b/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
@@ -175,8 +175,16 @@ def run_translation_workflow(
         baseline = BaselineTranslationPipeline(
             source_lang=config.source_lang,
             target_lang=config.target_lang,
+            model=config.model,
+            base_url=config.base_url,
+            temperature=config.temperature,
+            timeout=config.timeout,
         )
         _run_with_capture("baseline", lambda: baseline.translate_synset(synset_payload))
+        # Backwards compatibility: callers using "dspy" may read results["pipelines"]["dspy"].
+        # Share the same result object to avoid a second LLM call.
+        if selected == "dspy" and "baseline" in results["pipelines"]:
+            results["pipelines"]["dspy"] = results["pipelines"]["baseline"]
 
     if selected in {"langgraph", "all"}:
         lg = LangGraphTranslationPipeline(

--- a/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
+++ b/src/wordnet_autotranslate/workflows/synset_translation_workflow.py
@@ -14,7 +14,7 @@ import json
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-from ..pipelines.translation_pipeline import TranslationPipeline
+from ..pipelines.translation_pipeline import BaselineTranslationPipeline
 from ..pipelines.conceptual_langgraph_pipeline import ConceptualLangGraphTranslationPipeline
 from ..pipelines.langgraph_translation_pipeline import LangGraphTranslationPipeline
 from ..utils.language_utils import LanguageUtils
@@ -143,7 +143,14 @@ def run_translation_workflow(
     pipeline: str = "langgraph",
     config: WorkflowConfig = WorkflowConfig(),
 ) -> Dict[str, Any]:
-    """Run requested pipeline(s) for a synset payload."""
+    """Run requested pipeline(s) for a synset payload.
+
+    Supported workflows:
+    - baseline: dissertation baseline workflow (gloss + literals only)
+    - langgraph: dissertation multi-phase workflow
+    - conceptual: dissertation concept-oriented workflow
+    - dspy: legacy alias for baseline
+    """
     selected = pipeline.lower().strip()
 
     results: Dict[str, Any] = {
@@ -162,6 +169,14 @@ def run_translation_workflow(
                 "status": "error",
                 "message": str(exc),
             }
+
+    if selected in {"baseline", "dspy", "all"}:
+        # Legacy compatibility: "dspy" selector now maps to the dissertation baseline workflow.
+        baseline = BaselineTranslationPipeline(
+            source_lang=config.source_lang,
+            target_lang=config.target_lang,
+        )
+        _run_with_capture("baseline", lambda: baseline.translate_synset(synset_payload))
 
     if selected in {"langgraph", "all"}:
         lg = LangGraphTranslationPipeline(
@@ -185,22 +200,8 @@ def run_translation_workflow(
         )
         _run_with_capture("conceptual", lambda: cg.translate_synset(synset_payload))
 
-    if selected in {"dspy", "all"}:
-        dspy_pipeline = TranslationPipeline(
-            source_lang=config.source_lang,
-            target_lang=config.target_lang,
-        )
-        dspy_output = dspy_pipeline.translate([synset_payload])
-        if dspy_output:
-            results["pipelines"]["dspy"] = dspy_output[0]
-        else:
-            results["pipelines"]["dspy"] = {
-                "status": "not_implemented",
-                "message": "TranslationPipeline.translate currently returns no outputs for synsets.",
-            }
-
     if not results["pipelines"]:
-        raise ValueError("Unsupported pipeline. Use: langgraph | conceptual | all | dspy")
+        raise ValueError("Unsupported pipeline. Use: baseline | langgraph | conceptual | all | dspy")
 
     return results
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -27,7 +27,7 @@ def test_translation_pipeline_init():
     
     pipeline = TranslationPipeline()
     assert pipeline.source_lang == 'en'
-    assert pipeline.target_lang == 'es'
+    assert pipeline.target_lang == 'sr'
     
     pipeline_custom = TranslationPipeline(source_lang='en', target_lang='fr')
     assert pipeline_custom.source_lang == 'en'

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -46,6 +46,7 @@ def test_language_utils():
     # Test language names
     assert LanguageUtils.get_language_name('en') == 'English'
     assert LanguageUtils.get_language_name('es') == 'Spanish'
+    assert LanguageUtils.get_language_name('sr') == 'Serbian'
     
     # Test text cleaning
     test_text = "  Hello,   world!  "

--- a/tests/test_synset_translation_workflow.py
+++ b/tests/test_synset_translation_workflow.py
@@ -202,6 +202,7 @@ def test_run_translation_workflow_baseline_runs_for_legacy_dspy_alias():
     )
 
     assert "baseline" in result["pipelines"]
+    assert "dspy" in result["pipelines"]
     assert result["pipelines"]["baseline"]["source_lang"] == "en"
     assert result["pipelines"]["baseline"]["target_lang"] == "sr"
 

--- a/tests/test_synset_translation_workflow.py
+++ b/tests/test_synset_translation_workflow.py
@@ -189,7 +189,7 @@ def test_synset_to_payload_builds_expected_shape():
     assert payload["pos"] == "n"
 
 
-def test_run_translation_workflow_dspy_reports_not_implemented():
+def test_run_translation_workflow_baseline_runs_for_legacy_dspy_alias():
     result = run_translation_workflow(
         {
             "id": "ENG30-00001740-n",
@@ -201,9 +201,23 @@ def test_run_translation_workflow_dspy_reports_not_implemented():
         pipeline="dspy",
     )
 
-    assert "dspy" in result["pipelines"]
-    assert result["pipelines"]["dspy"]["status"] == "not_implemented"
+    assert "baseline" in result["pipelines"]
+    assert result["pipelines"]["baseline"]["source_lang"] == "en"
+    assert result["pipelines"]["baseline"]["target_lang"] == "sr"
 
+
+def test_run_translation_workflow_baseline_selector(monkeypatch):
+    class _FakeBaseline:
+        def __init__(self, **kwargs):
+            pass
+
+        def translate_synset(self, synset):
+            return {"translation": "baseline-only"}
+
+    monkeypatch.setattr(workflow_mod, "BaselineTranslationPipeline", _FakeBaseline)
+    result = run_translation_workflow({"id": "ENG30-00001740-n"}, pipeline="baseline")
+
+    assert result["pipelines"]["baseline"]["translation"] == "baseline-only"
 
 def test_run_translation_workflow_rejects_unknown_pipeline():
     with pytest.raises(ValueError, match="Unsupported pipeline"):
@@ -215,7 +229,7 @@ def test_resolve_sense_index_requires_positive_integer():
         _resolve_sense_index(0, 3)
 
 
-def test_run_translation_workflow_all_includes_dspy(monkeypatch):
+def test_run_translation_workflow_all_includes_baseline(monkeypatch):
     class _FakeLangGraph:
         def __init__(self, **kwargs):
             pass
@@ -230,13 +244,21 @@ def test_run_translation_workflow_all_includes_dspy(monkeypatch):
         def translate_synset(self, synset):
             return {"translation": "cg"}
 
+    class _FakeBaseline:
+        def __init__(self, **kwargs):
+            pass
+
+        def translate_synset(self, synset):
+            return {"translation": "base"}
+
+    monkeypatch.setattr(workflow_mod, "BaselineTranslationPipeline", _FakeBaseline)
     monkeypatch.setattr(workflow_mod, "LangGraphTranslationPipeline", _FakeLangGraph)
     monkeypatch.setattr(
         workflow_mod, "ConceptualLangGraphTranslationPipeline", _FakeConceptual
     )
 
     result = run_translation_workflow({"id": "ENG30-00001740-n"}, pipeline="all")
-    assert set(result["pipelines"]) == {"langgraph", "conceptual", "dspy"}
+    assert set(result["pipelines"]) == {"baseline", "langgraph", "conceptual"}
 
 
 def test_run_translation_workflow_capture_errors_when_non_strict(monkeypatch):

--- a/tests/test_translate_synset_cli.py
+++ b/tests/test_translate_synset_cli.py
@@ -26,3 +26,9 @@ def test_cli_keyboard_interrupt_returns_130(monkeypatch):
 
     monkeypatch.setattr(cli, "resolve_wordnet_synset", _raise_interrupt)
     assert cli.main() == 130
+
+
+def test_cli_pipeline_choices_include_baseline():
+    parser = cli.build_parser()
+    pipeline_action = next(action for action in parser._actions if action.dest == "pipeline")
+    assert "baseline" in pipeline_action.choices


### PR DESCRIPTION
Review feedback on the baseline pipeline revealed four correctness issues: no LLM was ever wired to the baseline even when `WorkflowConfig` carried full model config; `llm.invoke()` was called with a raw role/content dict list incompatible with LangChain chat models; the prompt hardcoded "English" regardless of `source_lang`; and `pipeline="dspy"` callers lost backwards compatibility because results were only stored under `"baseline"`.

## Changes

- **`BaselineTranslationPipeline`** — added `model`, `base_url`, `temperature`, `timeout` params; new `_build_llm()` auto-constructs `ChatOllama` when `langchain_ollama` is available, falls back to `None` (deterministic path) when not

- **`llm.invoke()` format** — replaced `[{"role": "system", ...}, {"role": "user", ...}]` with a single merged string:
  ```python
  combined_prompt = (
      f"System instructions:\n{self.system_prompt}\n\n"
      f"User request:\n{prompt}"
  )
  response = self.llm.invoke(combined_prompt)
  ```

- **Dynamic source language labels** — `_render_prompt` now derives labels via `LanguageUtils.get_language_name(self.source_lang)` so non-English sources produce correct prompts instead of "English literals / English gloss"

- **Workflow runner** — passes full `WorkflowConfig` (`model`, `base_url`, `temperature`, `timeout`) when constructing `BaselineTranslationPipeline`

- **`dspy` backwards compat** — result is now stored under both `"baseline"` and `"dspy"` keys (shared reference, no second LLM call) when `pipeline="dspy"` is selected; test updated to assert both keys